### PR TITLE
Cannot use RouteHelper as RouteHelper already in use in Helper\TemplateHelper.php

### DIFF
--- a/src/Cobalt/Helper/TemplateHelper.php
+++ b/src/Cobalt/Helper/TemplateHelper.php
@@ -11,7 +11,6 @@
 namespace Cobalt\Helper;
 
 use JFactory;
-use RouteHelper;
 use JUri;
 
 use Cobalt\Model\Menu as MenuModel;


### PR DESCRIPTION
Fatal error: Cannot use RouteHelper as RouteHelper because the name is already in use in C:\wamp\www\cobalt-master\src\Cobalt\Helper\TemplateHelper.php on line 14
