### PR TITLE
Logout fails with Namespace declaration useless

### DIFF
--- a/libraries/modular/authenticate/authenticate.php
+++ b/libraries/modular/authenticate/authenticate.php
@@ -7,8 +7,6 @@
  */
 defined('_CEXEC') or die;
 
-namespace Cobalt;
-
 use Cobalt\Container;
 use Cobalt\Model\User;
 


### PR DESCRIPTION
The error message is : Namespace declaration statement has to be the very first statement in the script located in File: ...\cobalt-master\libraries\modular\authenticate\authenticate.php:11
