### PR TITLE
Framework Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 /.idea
 /_install
 /vendor
-/composer.lock
 /build/packaging
 /build/packages/*
 !/build/packages/.placeholder

--- a/build/package_devhead.php
+++ b/build/package_devhead.php
@@ -42,19 +42,217 @@ system('rm vendor/filp/whoops/CONTRIBUTING.md');
 system('rm vendor/filp/whoops/phpunit.xml.dist');
 system('rm vendor/filp/whoops/README.md');
 
-// joomla/framework
-system('rm -rf vendor/joomla/framework/build');
-system('rm -rf vendor/joomla/framework/docs');
-system('rm -rf vendor/joomla/framework/tests');
-system('rm vendor/joomla/framework/.gitattributes');
-system('rm vendor/joomla/framework/.gitignore');
-system('rm vendor/joomla/framework/.gitmodules');
-system('rm vendor/joomla/framework/.travis.yml');
-system('rm vendor/joomla/framework/build.xml');
-system('rm vendor/joomla/framework/composer.json');
-system('rm vendor/joomla/framework/CONTRIBUTING.markdown');
-system('rm vendor/joomla/framework/phpunit.*');
-system('rm vendor/joomla/framework/README.markdown');
+// joomla/application
+system('rm -rf vendor/joomla/application/.travis');
+system('rm -rf vendor/joomla/application/Tests');
+system('rm vendor/joomla/application/.gitattributes');
+system('rm vendor/joomla/application/.gitignore');
+system('rm vendor/joomla/application/.gitmodules');
+system('rm vendor/joomla/application/.travis.yml');
+system('rm vendor/joomla/application/composer.json');
+system('rm vendor/joomla/application/CONTRIBUTING.md');
+system('rm vendor/joomla/application/phpunit.*');
+system('rm vendor/joomla/application/README.md');
+
+// joomla/compat
+system('rm vendor/joomla/compat/composer.json');
+system('rm vendor/joomla/compat/README.md');
+
+// joomla/controller
+system('rm -rf vendor/joomla/controller/.travis');
+system('rm -rf vendor/joomla/controller/Tests');
+system('rm vendor/joomla/controller/.gitattributes');
+system('rm vendor/joomla/controller/.gitignore');
+system('rm vendor/joomla/controller/.gitmodules');
+system('rm vendor/joomla/controller/.travis.yml');
+system('rm vendor/joomla/controller/composer.json');
+system('rm vendor/joomla/controller/CONTRIBUTING.md');
+system('rm vendor/joomla/controller/phpunit.*');
+system('rm vendor/joomla/controller/README.md');
+
+// joomla/crypt
+system('rm -rf vendor/joomla/session/Joomla/Session/Tests');
+system('rm vendor/joomla/session/Joomla/Session/.gitattributes');
+system('rm vendor/joomla/session/Joomla/Session/.gitignore');
+system('rm vendor/joomla/session/Joomla/Session/.travis.yml');
+system('rm vendor/joomla/session/Joomla/Session/composer.json');
+system('rm vendor/joomla/session/Joomla/Session/phpunit.*');
+system('rm vendor/joomla/session/Joomla/Session/README.md');
+
+// joomla/database
+system('rm -rf vendor/joomla/database/.travis');
+system('rm -rf vendor/joomla/database/Tests');
+system('rm vendor/joomla/database/.gitattributes');
+system('rm vendor/joomla/database/.gitignore');
+system('rm vendor/joomla/database/.gitmodules');
+system('rm vendor/joomla/database/.travis.yml');
+system('rm vendor/joomla/database/composer.json');
+system('rm vendor/joomla/database/CONTRIBUTING.md');
+system('rm vendor/joomla/database/phpunit.*');
+system('rm vendor/joomla/database/README.md');
+
+// joomla/date
+system('rm -rf vendor/joomla/date/Tests');
+system('rm vendor/joomla/date/composer.json');
+system('rm vendor/joomla/date/phpunit.*');
+system('rm vendor/joomla/date/README.md');
+
+// joomla/event
+system('rm -rf vendor/joomla/event/.travis');
+system('rm -rf vendor/joomla/event/Tests');
+system('rm vendor/joomla/event/.gitignore');
+system('rm vendor/joomla/event/.gitmodules');
+system('rm vendor/joomla/event/.travis.yml');
+system('rm vendor/joomla/event/composer.json');
+system('rm vendor/joomla/event/CONTRIBUTING.md');
+system('rm vendor/joomla/event/phpunit.*');
+system('rm vendor/joomla/event/README.md');
+
+// joomla/filesystem
+system('rm -rf vendor/joomla/filesystem/.travis');
+system('rm -rf vendor/joomla/filesystem/Tests');
+system('rm vendor/joomla/filesystem/.gitattributes');
+system('rm vendor/joomla/filesystem/.gitignore');
+system('rm vendor/joomla/filesystem/.gitmodules');
+system('rm vendor/joomla/filesystem/.travis.yml');
+system('rm vendor/joomla/filesystem/composer.json');
+system('rm vendor/joomla/filesystem/CONTRIBUTING.md');
+system('rm vendor/joomla/filesystem/phpunit.*');
+system('rm vendor/joomla/filesystem/README.md');
+
+// joomla/filter
+system('rm -rf vendor/joomla/filter/.travis');
+system('rm -rf vendor/joomla/filter/Tests');
+system('rm vendor/joomla/filter/.gitattributes');
+system('rm vendor/joomla/filter/.gitignore');
+system('rm vendor/joomla/filter/.gitmodules');
+system('rm vendor/joomla/filter/.travis.yml');
+system('rm vendor/joomla/filter/composer.json');
+system('rm vendor/joomla/filter/CONTRIBUTING.md');
+system('rm vendor/joomla/filter/phpunit.*');
+system('rm vendor/joomla/filter/README.md');
+
+// joomla/image
+system('rm -rf vendor/joomla/image/.travis');
+system('rm -rf vendor/joomla/image/Tests');
+system('rm vendor/joomla/image/.gitattributes');
+system('rm vendor/joomla/image/.gitignore');
+system('rm vendor/joomla/image/.gitmodules');
+system('rm vendor/joomla/image/.travis.yml');
+system('rm vendor/joomla/image/composer.json');
+system('rm vendor/joomla/image/CONTRIBUTING.md');
+system('rm vendor/joomla/image/phpunit.*');
+system('rm vendor/joomla/image/README.md');
+
+// joomla/input
+system('rm -rf vendor/joomla/input/Tests');
+system('rm vendor/joomla/input/composer.json');
+system('rm vendor/joomla/input/phpunit.*');
+system('rm vendor/joomla/input/README.md');
+
+// joomla/language
+system('rm -rf vendor/joomla/language/.travis');
+system('rm -rf vendor/joomla/language/Tests');
+system('rm vendor/joomla/language/.gitattributes');
+system('rm vendor/joomla/language/.gitignore');
+system('rm vendor/joomla/language/.gitmodules');
+system('rm vendor/joomla/language/.travis.yml');
+system('rm vendor/joomla/language/composer.json');
+system('rm vendor/joomla/language/CONTRIBUTING.md');
+system('rm vendor/joomla/language/phpunit.*');
+system('rm vendor/joomla/language/README.md');
+
+// joomla/model
+system('rm -rf vendor/joomla/model/.travis');
+system('rm -rf vendor/joomla/model/Tests');
+system('rm vendor/joomla/model/.gitattributes');
+system('rm vendor/joomla/model/.gitignore');
+system('rm vendor/joomla/model/.gitmodules');
+system('rm vendor/joomla/model/.travis.yml');
+system('rm vendor/joomla/model/composer.json');
+system('rm vendor/joomla/model/CONTRIBUTING.md');
+system('rm vendor/joomla/model/phpunit.*');
+system('rm vendor/joomla/model/README.md');
+
+// joomla/registry
+system('rm -rf vendor/joomla/registry/.travis');
+system('rm -rf vendor/joomla/registry/Tests');
+system('rm vendor/joomla/registry/.gitattributes');
+system('rm vendor/joomla/registry/.gitignore');
+system('rm vendor/joomla/registry/.gitmodules');
+system('rm vendor/joomla/registry/.travis.yml');
+system('rm vendor/joomla/registry/composer.json');
+system('rm vendor/joomla/registry/CONTRIBUTING.md');
+system('rm vendor/joomla/registry/phpunit.*');
+system('rm vendor/joomla/registry/README.md');
+
+// joomla/router
+system('rm -rf vendor/joomla/router/.travis');
+system('rm -rf vendor/joomla/router/Tests');
+system('rm vendor/joomla/router/.gitattributes');
+system('rm vendor/joomla/router/.gitignore');
+system('rm vendor/joomla/router/.gitmodules');
+system('rm vendor/joomla/router/.travis.yml');
+system('rm vendor/joomla/router/composer.json');
+system('rm vendor/joomla/router/CONTRIBUTING.md');
+system('rm vendor/joomla/router/phpunit.*');
+system('rm vendor/joomla/router/README.md');
+
+// joomla/session
+system('rm -rf vendor/joomla/session/Joomla/Session/_Tests');
+system('rm -rf vendor/joomla/session/Joomla/Session/build');
+system('rm -rf vendor/joomla/session/Joomla/Session/Tests');
+system('rm vendor/joomla/session/Joomla/Session/composer.json');
+system('rm vendor/joomla/session/Joomla/Session/phpunit.*');
+system('rm vendor/joomla/session/Joomla/Session/README.md');
+
+// joomla/string
+system('rm -rf vendor/joomla/string/.travis');
+system('rm -rf vendor/joomla/string/Tests');
+system('rm vendor/joomla/string/.gitattributes');
+system('rm vendor/joomla/string/.gitignore');
+system('rm vendor/joomla/string/.gitmodules');
+system('rm vendor/joomla/string/.travis.yml');
+system('rm vendor/joomla/string/composer.json');
+system('rm vendor/joomla/string/CONTRIBUTING.md');
+system('rm vendor/joomla/string/phpunit.*');
+system('rm vendor/joomla/string/README.md');
+
+// joomla/uri
+system('rm -rf vendor/joomla/uri/.travis');
+system('rm -rf vendor/joomla/uri/Tests');
+system('rm vendor/joomla/uri/.gitattributes');
+system('rm vendor/joomla/uri/.gitignore');
+system('rm vendor/joomla/uri/.gitmodules');
+system('rm vendor/joomla/uri/.travis.yml');
+system('rm vendor/joomla/uri/composer.json');
+system('rm vendor/joomla/uri/CONTRIBUTING.md');
+system('rm vendor/joomla/uri/phpunit.*');
+system('rm vendor/joomla/uri/README.md');
+
+// joomla/utilities
+system('rm -rf vendor/joomla/utilities/.travis');
+system('rm -rf vendor/joomla/utilities/Tests');
+system('rm vendor/joomla/utilities/.gitattributes');
+system('rm vendor/joomla/utilities/.gitignore');
+system('rm vendor/joomla/utilities/.gitmodules');
+system('rm vendor/joomla/utilities/.travis.yml');
+system('rm vendor/joomla/utilities/composer.json');
+system('rm vendor/joomla/utilities/CONTRIBUTING.md');
+system('rm vendor/joomla/utilities/phpunit.*');
+system('rm vendor/joomla/utilities/README.md');
+
+// joomla/view
+system('rm -rf vendor/joomla/view/.travis');
+system('rm -rf vendor/joomla/view/Tests');
+system('rm vendor/joomla/view/.gitattributes');
+system('rm vendor/joomla/view/.gitignore');
+system('rm vendor/joomla/view/.gitmodules');
+system('rm vendor/joomla/view/.travis.yml');
+system('rm vendor/joomla/view/composer.json');
+system('rm vendor/joomla/view/CONTRIBUTING.md');
+system('rm vendor/joomla/view/phpunit.*');
+system('rm vendor/joomla/view/README.md');
 
 // league/di
 system('rm -rf vendor/league/di/test');

--- a/composer.json
+++ b/composer.json
@@ -4,17 +4,31 @@
 	"license": "GPL-3.0",
 	"require": {
 		"php": ">=5.3.10",
-		"joomla/framework": "dev-master",
-		"joomla/database": "dev-master",
+		"joomla/application": "~1.2",
+		"joomla/controller": "~1.1",
+		"joomla/crypt": "~1.1",
+		"joomla/database": "~1.1",
+		"joomla/date": "~1.1",
+		"joomla/event": "~1.1",
+		"joomla/filesystem": "~1.1",
+		"joomla/filter": "~1.1",
+		"joomla/image": "~1.1",
+		"joomla/input": "~1.1",
+		"joomla/language": "~1.1",
+		"joomla/model": "~1.1",
+		"joomla/registry": "~1.2",
+		"joomla/router": "~1.1",
+		"joomla/string": "~1.2",
+		"joomla/view": "~1.1",
 		"symfony/http-foundation": "2.3.*@stable",
 		"league/di": "1.*",
 		"filp/whoops": "1.*",
 		"tracy/tracy": "2.2.3"
 	},
-    "autoload": {
-        "psr-0": {
-            "Cobalt\\": "src/"
-        }
-    },
+	"autoload": {
+		"psr-0": {
+			"Cobalt\\": "src/"
+		}
+	},
 	"minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"joomla/router": "~1.1",
 		"joomla/string": "~1.2",
 		"joomla/view": "~1.1",
-		"symfony/http-foundation": "2.3.*@stable",
+		"symfony/http-foundation": "2.3.*",
 		"league/di": "1.*",
 		"filp/whoops": "1.*",
 		"tracy/tracy": "2.2.3"
@@ -29,6 +29,5 @@
 		"psr-0": {
 			"Cobalt\\": "src/"
 		}
-	},
-	"minimum-stability": "dev"
+	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "04507558e7e991a7ee914d2c82eac606",
+    "hash": "3f5ed3f108fc8dc0f0c520120eb6d560",
     "packages": [
         {
             "name": "filp/whoops",
@@ -65,90 +65,943 @@
             "time": "2014-08-28 17:38:36"
         },
         {
-            "name": "joomla/framework",
+            "name": "joomla/application",
             "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/joomla/joomla-framework.git",
-                "reference": "c1be2eb75c38533a25d0106d3d381c8e6b228eb6"
+                "url": "https://github.com/joomla-framework/application.git",
+                "reference": "dda43fd39603d18ac7a53093bd8b89d07ef5e613"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla/joomla-framework/zipball/c1be2eb75c38533a25d0106d3d381c8e6b228eb6",
-                "reference": "c1be2eb75c38533a25d0106d3d381c8e6b228eb6",
+                "url": "https://api.github.com/repos/joomla-framework/application/zipball/dda43fd39603d18ac7a53093bd8b89d07ef5e613",
+                "reference": "dda43fd39603d18ac7a53093bd8b89d07ef5e613",
                 "shasum": ""
             },
             "require": {
+                "joomla/input": "~1.1.1",
+                "joomla/registry": "~1.1",
+                "joomla/session": "~1.1",
+                "joomla/string": "~1.1",
+                "joomla/uri": "~1.1",
                 "php": ">=5.3.10",
                 "psr/log": "~1.0"
             },
-            "replace": {
-                "joomla/application": "self.version",
-                "joomla/archive": "self.version",
-                "joomla/cache": "self.version",
-                "joomla/compat": "self.version",
-                "joomla/controller": "self.version",
-                "joomla/crypt": "self.version",
-                "joomla/data": "self.version",
-                "joomla/database": "self.version",
-                "joomla/date": "self.version",
-                "joomla/facebook": "self.version",
-                "joomla/filesystem": "self.version",
-                "joomla/filter": "self.version",
-                "joomla/form": "self.version",
-                "joomla/github": "self.version",
-                "joomla/google": "self.version",
-                "joomla/http": "self.version",
-                "joomla/image": "self.version",
-                "joomla/input": "self.version",
-                "joomla/keychain": "self.version",
-                "joomla/language": "self.version",
-                "joomla/linkedin": "self.version",
-                "joomla/log": "self.version",
-                "joomla/model": "self.version",
-                "joomla/oauth1": "self.version",
-                "joomla/oauth2": "self.version",
-                "joomla/profiler": "self.version",
-                "joomla/registry": "self.version",
-                "joomla/router": "self.version",
-                "joomla/session": "self.version",
-                "joomla/string": "self.version",
-                "joomla/test": "self.version",
-                "joomla/twitter": "self.version",
-                "joomla/uri": "self.version",
-                "joomla/utilities": "self.version",
-                "joomla/view": "self.version"
-            },
             "require-dev": {
-                "symfony/yaml": "~2.0"
+                "joomla/test": "~1.1",
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*"
             },
-            "suggest": {
-                "symfony/yaml": "Install symfony/yaml 2.* if you require YAML support."
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
             },
-            "type": "library",
             "autoload": {
-                "psr-0": {
-                    "Joomla": "src/",
-                    "Psr": "vendor/psr/cache"
-                },
+                "psr-4": {
+                    "Joomla\\Application\\": "src/",
+                    "Joomla\\Application\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Application Package",
+            "homepage": "https://github.com/joomla-framework/application",
+            "keywords": [
+                "application",
+                "framework",
+                "joomla"
+            ],
+            "time": "2014-09-02 12:27:00"
+        },
+        {
+            "name": "joomla/compat",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/compat.git",
+                "reference": "92ba45e9cfdca4c912691bf04ef13e0c03660348"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/compat/zipball/92ba45e9cfdca4c912691bf04ef13e0c03660348",
+                "reference": "92ba45e9cfdca4c912691bf04ef13e0c03660348",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.10"
+            },
+            "type": "joomla-package",
+            "autoload": {
                 "classmap": [
-                    "src/Joomla/Compat/JsonSerializable.php"
-                ],
-                "files": [
-                    "src/Joomla/PHP/methods.php"
+                    "src/JsonSerializable.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0+"
             ],
-            "description": "The Joomla Framework is a platform for writing Web and command line applications in PHP.",
-            "homepage": "https://github.com/joomla/joomla-framework",
+            "description": "Joomla Compat Package",
+            "homepage": "https://github.com/joomla-framework/compat",
             "keywords": [
+                "compat",
                 "framework",
                 "joomla"
             ],
-            "time": "2014-04-26 00:07:56"
+            "time": "2014-02-09 19:29:20"
+        },
+        {
+            "name": "joomla/controller",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/controller.git",
+                "reference": "fbf8946e176fe4f7d417113b924f3adaf1eef58e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/controller/zipball/fbf8946e176fe4f7d417113b924f3adaf1eef58e",
+                "reference": "fbf8946e176fe4f7d417113b924f3adaf1eef58e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.10"
+            },
+            "require-dev": {
+                "joomla/application": "~1.0",
+                "joomla/input": "~1.0",
+                "joomla/test": "~1.0",
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "suggest": {
+                "joomla/application": "~1.0",
+                "joomla/input": "~1.0"
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\Controller\\": "src/",
+                    "Joomla\\Controller\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Controller Package",
+            "homepage": "https://github.com/joomla-framework/controller",
+            "keywords": [
+                "controller",
+                "framework",
+                "joomla"
+            ],
+            "time": "2014-09-01 01:37:42"
+        },
+        {
+            "name": "joomla/crypt",
+            "version": "dev-1.x-dev",
+            "target-dir": "Joomla/Crypt",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/crypt.git",
+                "reference": "35c8d66f084be0e7ef5407409fc2054e0de8cefa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/crypt/zipball/35c8d66f084be0e7ef5407409fc2054e0de8cefa",
+                "reference": "35c8d66f084be0e7ef5407409fc2054e0de8cefa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.10"
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x-dev": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Joomla\\Crypt": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Crypt Package",
+            "homepage": "https://github.com/joomla-framework/crypt",
+            "keywords": [
+                "crypt",
+                "framework",
+                "joomla"
+            ],
+            "time": "2014-08-21 14:08:03"
+        },
+        {
+            "name": "joomla/database",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/database.git",
+                "reference": "bad8825c32de50430884b96a059515a45c034fbd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/database/zipball/bad8825c32de50430884b96a059515a45c034fbd",
+                "reference": "bad8825c32de50430884b96a059515a45c034fbd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.10",
+                "psr/log": "~1.0"
+            },
+            "require-dev": {
+                "joomla/test": "~1.0",
+                "phpunit/dbunit": "~1.2",
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\Database\\": "src/",
+                    "Joomla\\Database\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Database Package",
+            "homepage": "https://github.com/joomla-framework/database",
+            "keywords": [
+                "database",
+                "framework",
+                "joomla"
+            ],
+            "time": "2014-09-04 02:55:42"
+        },
+        {
+            "name": "joomla/date",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/date.git",
+                "reference": "b985dc1a4ed41ea14c90fc09347c6bb44470aeaa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/date/zipball/b985dc1a4ed41ea14c90fc09347c6bb44470aeaa",
+                "reference": "b985dc1a4ed41ea14c90fc09347c6bb44470aeaa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.10"
+            },
+            "type": "joomla-package",
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\Date\\": "src/",
+                    "Joomla\\Date\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Date Package",
+            "homepage": "https://github.com/joomla-framework/date",
+            "keywords": [
+                "date",
+                "framework",
+                "joomla"
+            ],
+            "time": "2014-02-09 01:27:57"
+        },
+        {
+            "name": "joomla/event",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/event.git",
+                "reference": "31031048afdbc7e41c4abf3cb66089d22f482b7f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/event/zipball/31031048afdbc7e41c4abf3cb66089d22f482b7f",
+                "reference": "31031048afdbc7e41c4abf3cb66089d22f482b7f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.10"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\Event\\": "src/",
+                    "Joomla\\Event\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Event Package",
+            "homepage": "https://github.com/joomla-framework/event",
+            "keywords": [
+                "event",
+                "framework",
+                "joomla"
+            ],
+            "time": "2014-09-01 01:47:26"
+        },
+        {
+            "name": "joomla/filesystem",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/filesystem.git",
+                "reference": "ae03a09c35e1aaf8e6ec30c19f3b085eafd698c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/filesystem/zipball/ae03a09c35e1aaf8e6ec30c19f3b085eafd698c5",
+                "reference": "ae03a09c35e1aaf8e6ec30c19f3b085eafd698c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.10"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\Filesystem\\": "src/",
+                    "Joomla\\Filesystem\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Filesystem Package",
+            "homepage": "https://github.com/joomla/joomla-framework-filesystem",
+            "keywords": [
+                "filesystem",
+                "framework",
+                "joomla"
+            ],
+            "time": "2014-09-01 01:50:51"
+        },
+        {
+            "name": "joomla/filter",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/filter.git",
+                "reference": "2f9618f8df410e51f6cd457203b8e20a5e4933bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/filter/zipball/2f9618f8df410e51f6cd457203b8e20a5e4933bd",
+                "reference": "2f9618f8df410e51f6cd457203b8e20a5e4933bd",
+                "shasum": ""
+            },
+            "require": {
+                "joomla/string": "~1.0",
+                "php": ">=5.3.10"
+            },
+            "require-dev": {
+                "joomla/language": "~1.0",
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "suggest": {
+                "joomla/language": "Required only if you want to use `OutputFilter::stringURLSafe`."
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\Filter\\": "src/",
+                    "Joomla\\Filter\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Filter Package",
+            "homepage": "https://github.com/joomla-framework/filter",
+            "keywords": [
+                "filter",
+                "framework",
+                "joomla"
+            ],
+            "time": "2014-09-01 01:52:44"
+        },
+        {
+            "name": "joomla/image",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/image.git",
+                "reference": "35fec0877bc7996a45545733d6811527231b28b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/image/zipball/35fec0877bc7996a45545733d6811527231b28b8",
+                "reference": "35fec0877bc7996a45545733d6811527231b28b8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gd": "*",
+                "php": ">=5.3.10",
+                "psr/log": "~1.0"
+            },
+            "require-dev": {
+                "joomla/test": "~1.0",
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\Image\\": "src/",
+                    "Joomla\\Image\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Image Package",
+            "homepage": "https://github.com/joomla-framework/image",
+            "keywords": [
+                "framework",
+                "image",
+                "joomla"
+            ],
+            "time": "2014-09-01 01:59:39"
+        },
+        {
+            "name": "joomla/input",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/input.git",
+                "reference": "8f6ea1ce7ba13d372725aa6c61b641903d1aa015"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/input/zipball/8f6ea1ce7ba13d372725aa6c61b641903d1aa015",
+                "reference": "8f6ea1ce7ba13d372725aa6c61b641903d1aa015",
+                "shasum": ""
+            },
+            "require": {
+                "joomla/filter": "~1.0",
+                "php": ">=5.3.10"
+            },
+            "require-dev": {
+                "joomla/test": "~1.0"
+            },
+            "type": "joomla-package",
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\Input\\": "src/",
+                    "Joomla\\Input\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Input Package",
+            "homepage": "https://github.com/joomla-framework/input",
+            "keywords": [
+                "framework",
+                "input",
+                "joomla"
+            ],
+            "time": "2014-08-23 19:16:46"
+        },
+        {
+            "name": "joomla/language",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/language.git",
+                "reference": "62d1090a3e8fc064b420ba8a9604bbb85c0fb478"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/language/zipball/62d1090a3e8fc064b420ba8a9604bbb85c0fb478",
+                "reference": "62d1090a3e8fc064b420ba8a9604bbb85c0fb478",
+                "shasum": ""
+            },
+            "require": {
+                "joomla/string": "~1.0",
+                "php": ">=5.3.10"
+            },
+            "require-dev": {
+                "joomla/filesystem": "~1.0",
+                "joomla/test": "~1.0",
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\Language\\": "src/",
+                    "Joomla\\Language\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Language Package",
+            "homepage": "https://github.com/joomla-framework/language",
+            "keywords": [
+                "framework",
+                "joomla",
+                "language"
+            ],
+            "time": "2014-09-01 02:04:17"
+        },
+        {
+            "name": "joomla/model",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/model.git",
+                "reference": "d495aa88e33b964ecc94ed8636be590e5084b8f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/model/zipball/d495aa88e33b964ecc94ed8636be590e5084b8f5",
+                "reference": "d495aa88e33b964ecc94ed8636be590e5084b8f5",
+                "shasum": ""
+            },
+            "require": {
+                "joomla/database": "~1.0",
+                "joomla/registry": "~1.0",
+                "php": ">=5.3.10"
+            },
+            "require-dev": {
+                "joomla/test": "~1.0",
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\Model\\": "src/",
+                    "Joomla\\Model\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Model Package",
+            "homepage": "https://github.com/joomla-framework/model",
+            "keywords": [
+                "framework",
+                "joomla",
+                "model"
+            ],
+            "time": "2014-09-01 02:08:45"
+        },
+        {
+            "name": "joomla/registry",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/registry.git",
+                "reference": "3a8b7837f9466df8e9ad568da31b303e470f3eaa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/registry/zipball/3a8b7837f9466df8e9ad568da31b303e470f3eaa",
+                "reference": "3a8b7837f9466df8e9ad568da31b303e470f3eaa",
+                "shasum": ""
+            },
+            "require": {
+                "joomla/compat": "~1.0",
+                "joomla/string": "~1.2",
+                "joomla/utilities": "~1.0",
+                "php": ">=5.3.10"
+            },
+            "require-dev": {
+                "joomla/test": "~1.0",
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*",
+                "symfony/yaml": "~2.0"
+            },
+            "suggest": {
+                "symfony/yaml": "Install 2.* if you require YAML support."
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\Registry\\": "src/",
+                    "Joomla\\Registry\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Registry Package",
+            "homepage": "https://github.com/joomla-framework/registry",
+            "keywords": [
+                "framework",
+                "joomla",
+                "registry"
+            ],
+            "time": "2014-09-03 16:09:19"
+        },
+        {
+            "name": "joomla/router",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/router.git",
+                "reference": "1374334a0b7190284755b744515eb99fe59fc978"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/router/zipball/1374334a0b7190284755b744515eb99fe59fc978",
+                "reference": "1374334a0b7190284755b744515eb99fe59fc978",
+                "shasum": ""
+            },
+            "require": {
+                "joomla/controller": "~1.0",
+                "joomla/input": "~1.0",
+                "php": ">=5.3.10"
+            },
+            "require-dev": {
+                "joomla/test": "~1.0",
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\Router\\": "src/",
+                    "Joomla\\Router\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Router Package",
+            "homepage": "https://github.com/joomla-framework/router",
+            "keywords": [
+                "framework",
+                "joomla",
+                "router"
+            ],
+            "time": "2014-09-01 02:17:33"
+        },
+        {
+            "name": "joomla/session",
+            "version": "1.2.3",
+            "target-dir": "Joomla/Session",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/session.git",
+                "reference": "ef955cf9642793c4ad5874f334069051c33ba604"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/session/zipball/ef955cf9642793c4ad5874f334069051c33ba604",
+                "reference": "ef955cf9642793c4ad5874f334069051c33ba604",
+                "shasum": ""
+            },
+            "require": {
+                "joomla/event": "~1.1",
+                "joomla/filter": "~1.0",
+                "php": ">=5.3.10"
+            },
+            "require-dev": {
+                "joomla/test": "~1.0"
+            },
+            "suggest": {
+                "joomla/database": "Install joomla/database if you want to use Database session storage."
+            },
+            "type": "joomla-package",
+            "autoload": {
+                "psr-0": {
+                    "Joomla\\Session": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Session Package",
+            "homepage": "https://github.com/joomla-framework/session",
+            "keywords": [
+                "framework",
+                "joomla",
+                "session"
+            ],
+            "time": "2014-08-18 17:41:06"
+        },
+        {
+            "name": "joomla/string",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/string.git",
+                "reference": "7c10c093ceae7e5a0a1002fe12e4dcf83ca386ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/string/zipball/7c10c093ceae7e5a0a1002fe12e4dcf83ca386ec",
+                "reference": "7c10c093ceae7e5a0a1002fe12e4dcf83ca386ec",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.10"
+            },
+            "require-dev": {
+                "joomla/test": "~1.0",
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\String\\": "src/",
+                    "Joomla\\String\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla String Package",
+            "homepage": "https://github.com/joomla-framework/string",
+            "keywords": [
+                "framework",
+                "joomla",
+                "string"
+            ],
+            "time": "2014-09-01 02:25:33"
+        },
+        {
+            "name": "joomla/uri",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/uri.git",
+                "reference": "c955ddfb396752fb87b3275db9c1d66effa4262c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/uri/zipball/c955ddfb396752fb87b3275db9c1d66effa4262c",
+                "reference": "c955ddfb396752fb87b3275db9c1d66effa4262c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.10"
+            },
+            "require-dev": {
+                "joomla/test": "~1.0",
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\Uri\\": "src/",
+                    "Joomla\\Uri\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Uri Package",
+            "homepage": "https://github.com/joomla-framework/uri",
+            "keywords": [
+                "framework",
+                "joomla",
+                "uri"
+            ],
+            "time": "2014-09-01 03:05:41"
+        },
+        {
+            "name": "joomla/utilities",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/utilities.git",
+                "reference": "f749a9bd6f2fc5ad376687651478273dac105051"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/utilities/zipball/f749a9bd6f2fc5ad376687651478273dac105051",
+                "reference": "f749a9bd6f2fc5ad376687651478273dac105051",
+                "shasum": ""
+            },
+            "require": {
+                "joomla/string": "~1.0",
+                "php": ">=5.3.10"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\Utilities\\": "src/",
+                    "Joomla\\Utilities\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Utilities Package",
+            "homepage": "https://github.com/joomla-framework/utilities",
+            "keywords": [
+                "framework",
+                "joomla",
+                "utilities"
+            ],
+            "time": "2014-09-03 21:44:44"
+        },
+        {
+            "name": "joomla/view",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/view.git",
+                "reference": "2254fec4b1a11d2dfd0fe9dd096b263194583d22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/view/zipball/2254fec4b1a11d2dfd0fe9dd096b263194583d22",
+                "reference": "2254fec4b1a11d2dfd0fe9dd096b263194583d22",
+                "shasum": ""
+            },
+            "require": {
+                "joomla/filesystem": "~1.0",
+                "joomla/model": "~1.0",
+                "php": ">=5.3.10"
+            },
+            "require-dev": {
+                "joomla/test": "~1.0",
+                "phpunit/phpunit": "4.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\View\\": "src/",
+                    "Joomla\\View\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla View Package",
+            "homepage": "https://github.com/joomla-framework/view",
+            "keywords": [
+                "framework",
+                "joomla",
+                "view"
+            ],
+            "time": "2014-09-01 02:30:31"
         },
         {
             "name": "league/di",
@@ -352,8 +1205,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "joomla/framework": 20,
-        "joomla/database": 20,
         "symfony/http-foundation": 0
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3f5ed3f108fc8dc0f0c520120eb6d560",
+    "hash": "f230f9ea17c9774ccd07461968a749b1",
     "packages": [
         {
             "name": "filp/whoops",
-            "version": "dev-master",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "6ad204c4280b0f178ab903047cb684ce66c4954b"
+                "reference": "9f451fbc7b8cad5e71300672c340c28c6bec09ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/6ad204c4280b0f178ab903047cb684ce66c4954b",
-                "reference": "6ad204c4280b0f178ab903047cb684ce66c4954b",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/9f451fbc7b8cad5e71300672c340c28c6bec09ff",
+                "reference": "9f451fbc7b8cad5e71300672c340c28c6bec09ff",
                 "shasum": ""
             },
             "require": {
@@ -62,20 +62,20 @@
                 "whoops",
                 "zf2"
             ],
-            "time": "2014-08-28 17:38:36"
+            "time": "2014-07-11 05:56:54"
         },
         {
             "name": "joomla/application",
-            "version": "dev-master",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/application.git",
-                "reference": "dda43fd39603d18ac7a53093bd8b89d07ef5e613"
+                "reference": "6eaa27a50d5362cf5d73acf9eade50ae042097da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/application/zipball/dda43fd39603d18ac7a53093bd8b89d07ef5e613",
-                "reference": "dda43fd39603d18ac7a53093bd8b89d07ef5e613",
+                "url": "https://api.github.com/repos/joomla-framework/application/zipball/6eaa27a50d5362cf5d73acf9eade50ae042097da",
+                "reference": "6eaa27a50d5362cf5d73acf9eade50ae042097da",
                 "shasum": ""
             },
             "require": {
@@ -88,16 +88,9 @@
                 "psr/log": "~1.0"
             },
             "require-dev": {
-                "joomla/test": "~1.1",
-                "phpunit/phpunit": "4.*",
-                "squizlabs/php_codesniffer": "1.*"
+                "joomla/test": "~1.1"
             },
             "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Joomla\\Application\\": "src/",
@@ -115,7 +108,7 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2014-09-02 12:27:00"
+            "time": "2014-05-20 14:35:14"
         },
         {
             "name": "joomla/compat",
@@ -155,16 +148,16 @@
         },
         {
             "name": "joomla/controller",
-            "version": "dev-master",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/controller.git",
-                "reference": "fbf8946e176fe4f7d417113b924f3adaf1eef58e"
+                "reference": "5177cf40e146c74d71f0c04ef0568d549afd564c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/controller/zipball/fbf8946e176fe4f7d417113b924f3adaf1eef58e",
-                "reference": "fbf8946e176fe4f7d417113b924f3adaf1eef58e",
+                "url": "https://api.github.com/repos/joomla-framework/controller/zipball/5177cf40e146c74d71f0c04ef0568d549afd564c",
+                "reference": "5177cf40e146c74d71f0c04ef0568d549afd564c",
                 "shasum": ""
             },
             "require": {
@@ -173,20 +166,13 @@
             "require-dev": {
                 "joomla/application": "~1.0",
                 "joomla/input": "~1.0",
-                "joomla/test": "~1.0",
-                "phpunit/phpunit": "4.*",
-                "squizlabs/php_codesniffer": "1.*"
+                "joomla/test": "~1.0"
             },
             "suggest": {
                 "joomla/application": "~1.0",
                 "joomla/input": "~1.0"
             },
             "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Joomla\\Controller\\": "src/",
@@ -204,32 +190,27 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2014-09-01 01:37:42"
+            "time": "2014-02-09 01:25:57"
         },
         {
             "name": "joomla/crypt",
-            "version": "dev-1.x-dev",
+            "version": "1.1.0",
             "target-dir": "Joomla/Crypt",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/crypt.git",
-                "reference": "35c8d66f084be0e7ef5407409fc2054e0de8cefa"
+                "reference": "972e24f5a5c2edd307d57f9d299db0722c8e077f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/crypt/zipball/35c8d66f084be0e7ef5407409fc2054e0de8cefa",
-                "reference": "35c8d66f084be0e7ef5407409fc2054e0de8cefa",
+                "url": "https://api.github.com/repos/joomla-framework/crypt/zipball/972e24f5a5c2edd307d57f9d299db0722c8e077f",
+                "reference": "972e24f5a5c2edd307d57f9d299db0722c8e077f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.10"
             },
             "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x-dev": "1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-0": {
                     "Joomla\\Crypt": ""
@@ -240,26 +221,26 @@
                 "GPL-2.0+"
             ],
             "description": "Joomla Crypt Package",
-            "homepage": "https://github.com/joomla-framework/crypt",
+            "homepage": "https://github.com/joomla/joomla-framework-crypt",
             "keywords": [
                 "crypt",
                 "framework",
                 "joomla"
             ],
-            "time": "2014-08-21 14:08:03"
+            "time": "2013-12-02 00:36:30"
         },
         {
             "name": "joomla/database",
-            "version": "dev-master",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/database.git",
-                "reference": "bad8825c32de50430884b96a059515a45c034fbd"
+                "reference": "2b979896577e2f0d05ac2cec9734dc5b35650067"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/database/zipball/bad8825c32de50430884b96a059515a45c034fbd",
-                "reference": "bad8825c32de50430884b96a059515a45c034fbd",
+                "url": "https://api.github.com/repos/joomla-framework/database/zipball/2b979896577e2f0d05ac2cec9734dc5b35650067",
+                "reference": "2b979896577e2f0d05ac2cec9734dc5b35650067",
                 "shasum": ""
             },
             "require": {
@@ -267,17 +248,9 @@
                 "psr/log": "~1.0"
             },
             "require-dev": {
-                "joomla/test": "~1.0",
-                "phpunit/dbunit": "~1.2",
-                "phpunit/phpunit": "4.*",
-                "squizlabs/php_codesniffer": "1.*"
+                "joomla/test": "~1.0"
             },
             "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Joomla\\Database\\": "src/",
@@ -295,7 +268,7 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2014-09-04 02:55:42"
+            "time": "2014-08-17 17:41:07"
         },
         {
             "name": "joomla/date",
@@ -336,31 +309,22 @@
         },
         {
             "name": "joomla/event",
-            "version": "dev-master",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/event.git",
-                "reference": "31031048afdbc7e41c4abf3cb66089d22f482b7f"
+                "reference": "bb957bc45aba897e465384bbe21cd0eb79aca901"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/event/zipball/31031048afdbc7e41c4abf3cb66089d22f482b7f",
-                "reference": "31031048afdbc7e41c4abf3cb66089d22f482b7f",
+                "url": "https://api.github.com/repos/joomla-framework/event/zipball/bb957bc45aba897e465384bbe21cd0eb79aca901",
+                "reference": "bb957bc45aba897e465384bbe21cd0eb79aca901",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.10"
             },
-            "require-dev": {
-                "phpunit/phpunit": "4.*",
-                "squizlabs/php_codesniffer": "1.*"
-            },
             "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Joomla\\Event\\": "src/",
@@ -378,35 +342,26 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2014-09-01 01:47:26"
+            "time": "2014-02-09 01:30:54"
         },
         {
             "name": "joomla/filesystem",
-            "version": "dev-master",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/filesystem.git",
-                "reference": "ae03a09c35e1aaf8e6ec30c19f3b085eafd698c5"
+                "reference": "31884adf5470baf14de74bfd36482fd18ae048ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/filesystem/zipball/ae03a09c35e1aaf8e6ec30c19f3b085eafd698c5",
-                "reference": "ae03a09c35e1aaf8e6ec30c19f3b085eafd698c5",
+                "url": "https://api.github.com/repos/joomla-framework/filesystem/zipball/31884adf5470baf14de74bfd36482fd18ae048ad",
+                "reference": "31884adf5470baf14de74bfd36482fd18ae048ad",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.10"
             },
-            "require-dev": {
-                "phpunit/phpunit": "4.*",
-                "squizlabs/php_codesniffer": "1.*"
-            },
             "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Joomla\\Filesystem\\": "src/",
@@ -424,20 +379,20 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2014-09-01 01:50:51"
+            "time": "2014-04-10 02:54:58"
         },
         {
             "name": "joomla/filter",
-            "version": "dev-master",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/filter.git",
-                "reference": "2f9618f8df410e51f6cd457203b8e20a5e4933bd"
+                "reference": "bd097a34c1f94d54589462c960fd41921e61c1c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/filter/zipball/2f9618f8df410e51f6cd457203b8e20a5e4933bd",
-                "reference": "2f9618f8df410e51f6cd457203b8e20a5e4933bd",
+                "url": "https://api.github.com/repos/joomla-framework/filter/zipball/bd097a34c1f94d54589462c960fd41921e61c1c9",
+                "reference": "bd097a34c1f94d54589462c960fd41921e61c1c9",
                 "shasum": ""
             },
             "require": {
@@ -445,19 +400,12 @@
                 "php": ">=5.3.10"
             },
             "require-dev": {
-                "joomla/language": "~1.0",
-                "phpunit/phpunit": "4.*",
-                "squizlabs/php_codesniffer": "1.*"
+                "joomla/language": "~1.0"
             },
             "suggest": {
                 "joomla/language": "Required only if you want to use `OutputFilter::stringURLSafe`."
             },
             "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Joomla\\Filter\\": "src/",
@@ -475,20 +423,20 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2014-09-01 01:52:44"
+            "time": "2014-02-09 07:45:50"
         },
         {
             "name": "joomla/image",
-            "version": "dev-master",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/image.git",
-                "reference": "35fec0877bc7996a45545733d6811527231b28b8"
+                "reference": "53d7c57554269a7671b9fc788d6b186fed18bd69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/image/zipball/35fec0877bc7996a45545733d6811527231b28b8",
-                "reference": "35fec0877bc7996a45545733d6811527231b28b8",
+                "url": "https://api.github.com/repos/joomla-framework/image/zipball/53d7c57554269a7671b9fc788d6b186fed18bd69",
+                "reference": "53d7c57554269a7671b9fc788d6b186fed18bd69",
                 "shasum": ""
             },
             "require": {
@@ -497,16 +445,9 @@
                 "psr/log": "~1.0"
             },
             "require-dev": {
-                "joomla/test": "~1.0",
-                "phpunit/phpunit": "4.*",
-                "squizlabs/php_codesniffer": "1.*"
+                "joomla/test": "~1.0"
             },
             "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Joomla\\Image\\": "src/",
@@ -524,7 +465,7 @@
                 "image",
                 "joomla"
             ],
-            "time": "2014-09-01 01:59:39"
+            "time": "2014-08-23 20:02:17"
         },
         {
             "name": "joomla/input",
@@ -569,16 +510,16 @@
         },
         {
             "name": "joomla/language",
-            "version": "dev-master",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/language.git",
-                "reference": "62d1090a3e8fc064b420ba8a9604bbb85c0fb478"
+                "reference": "3261f4179e4e5110d6cbab271ab6ae2aefd29e84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/language/zipball/62d1090a3e8fc064b420ba8a9604bbb85c0fb478",
-                "reference": "62d1090a3e8fc064b420ba8a9604bbb85c0fb478",
+                "url": "https://api.github.com/repos/joomla-framework/language/zipball/3261f4179e4e5110d6cbab271ab6ae2aefd29e84",
+                "reference": "3261f4179e4e5110d6cbab271ab6ae2aefd29e84",
                 "shasum": ""
             },
             "require": {
@@ -587,16 +528,9 @@
             },
             "require-dev": {
                 "joomla/filesystem": "~1.0",
-                "joomla/test": "~1.0",
-                "phpunit/phpunit": "4.*",
-                "squizlabs/php_codesniffer": "1.*"
+                "joomla/test": "~1.0"
             },
             "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Joomla\\Language\\": "src/",
@@ -614,20 +548,20 @@
                 "joomla",
                 "language"
             ],
-            "time": "2014-09-01 02:04:17"
+            "time": "2014-08-23 19:42:44"
         },
         {
             "name": "joomla/model",
-            "version": "dev-master",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/model.git",
-                "reference": "d495aa88e33b964ecc94ed8636be590e5084b8f5"
+                "reference": "f0aa791c67c8d02fcdcb7c98c13e2222fb03b9b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/model/zipball/d495aa88e33b964ecc94ed8636be590e5084b8f5",
-                "reference": "d495aa88e33b964ecc94ed8636be590e5084b8f5",
+                "url": "https://api.github.com/repos/joomla-framework/model/zipball/f0aa791c67c8d02fcdcb7c98c13e2222fb03b9b9",
+                "reference": "f0aa791c67c8d02fcdcb7c98c13e2222fb03b9b9",
                 "shasum": ""
             },
             "require": {
@@ -636,16 +570,9 @@
                 "php": ">=5.3.10"
             },
             "require-dev": {
-                "joomla/test": "~1.0",
-                "phpunit/phpunit": "4.*",
-                "squizlabs/php_codesniffer": "1.*"
+                "joomla/test": "~1.0"
             },
             "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Joomla\\Model\\": "src/",
@@ -663,11 +590,11 @@
                 "joomla",
                 "model"
             ],
-            "time": "2014-09-01 02:08:45"
+            "time": "2014-02-09 02:18:14"
         },
         {
             "name": "joomla/registry",
-            "version": "dev-master",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/registry.git",
@@ -721,16 +648,16 @@
         },
         {
             "name": "joomla/router",
-            "version": "dev-master",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/router.git",
-                "reference": "1374334a0b7190284755b744515eb99fe59fc978"
+                "reference": "e7a22af3ae07ab33999c575dff29ab423b662859"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/router/zipball/1374334a0b7190284755b744515eb99fe59fc978",
-                "reference": "1374334a0b7190284755b744515eb99fe59fc978",
+                "url": "https://api.github.com/repos/joomla-framework/router/zipball/e7a22af3ae07ab33999c575dff29ab423b662859",
+                "reference": "e7a22af3ae07ab33999c575dff29ab423b662859",
                 "shasum": ""
             },
             "require": {
@@ -739,16 +666,9 @@
                 "php": ">=5.3.10"
             },
             "require-dev": {
-                "joomla/test": "~1.0",
-                "phpunit/phpunit": "4.*",
-                "squizlabs/php_codesniffer": "1.*"
+                "joomla/test": "~1.0"
             },
             "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Joomla\\Router\\": "src/",
@@ -766,7 +686,7 @@
                 "joomla",
                 "router"
             ],
-            "time": "2014-09-01 02:17:33"
+            "time": "2014-08-23 19:40:48"
         },
         {
             "name": "joomla/session",
@@ -815,32 +735,25 @@
         },
         {
             "name": "joomla/string",
-            "version": "dev-master",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/string.git",
-                "reference": "7c10c093ceae7e5a0a1002fe12e4dcf83ca386ec"
+                "reference": "f1152e6cce135ff90f4b0097792e8be23989b143"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/string/zipball/7c10c093ceae7e5a0a1002fe12e4dcf83ca386ec",
-                "reference": "7c10c093ceae7e5a0a1002fe12e4dcf83ca386ec",
+                "url": "https://api.github.com/repos/joomla-framework/string/zipball/f1152e6cce135ff90f4b0097792e8be23989b143",
+                "reference": "f1152e6cce135ff90f4b0097792e8be23989b143",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.10"
             },
             "require-dev": {
-                "joomla/test": "~1.0",
-                "phpunit/phpunit": "4.*",
-                "squizlabs/php_codesniffer": "1.*"
+                "joomla/test": "~1.0"
             },
             "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Joomla\\String\\": "src/",
@@ -858,36 +771,26 @@
                 "joomla",
                 "string"
             ],
-            "time": "2014-09-01 02:25:33"
+            "time": "2014-08-23 19:33:54"
         },
         {
             "name": "joomla/uri",
-            "version": "dev-master",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/uri.git",
-                "reference": "c955ddfb396752fb87b3275db9c1d66effa4262c"
+                "reference": "980e532e4235bb8f1ada15b28822abbeb171da3f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/uri/zipball/c955ddfb396752fb87b3275db9c1d66effa4262c",
-                "reference": "c955ddfb396752fb87b3275db9c1d66effa4262c",
+                "url": "https://api.github.com/repos/joomla-framework/uri/zipball/980e532e4235bb8f1ada15b28822abbeb171da3f",
+                "reference": "980e532e4235bb8f1ada15b28822abbeb171da3f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.10"
             },
-            "require-dev": {
-                "joomla/test": "~1.0",
-                "phpunit/phpunit": "4.*",
-                "squizlabs/php_codesniffer": "1.*"
-            },
             "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Joomla\\Uri\\": "src/",
@@ -905,11 +808,11 @@
                 "joomla",
                 "uri"
             ],
-            "time": "2014-09-01 03:05:41"
+            "time": "2014-02-09 02:57:17"
         },
         {
             "name": "joomla/utilities",
-            "version": "dev-master",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/utilities.git",
@@ -956,16 +859,16 @@
         },
         {
             "name": "joomla/view",
-            "version": "dev-master",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/view.git",
-                "reference": "2254fec4b1a11d2dfd0fe9dd096b263194583d22"
+                "reference": "4f368e317921f580a455adc3b95b3423e53ea8e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/view/zipball/2254fec4b1a11d2dfd0fe9dd096b263194583d22",
-                "reference": "2254fec4b1a11d2dfd0fe9dd096b263194583d22",
+                "url": "https://api.github.com/repos/joomla-framework/view/zipball/4f368e317921f580a455adc3b95b3423e53ea8e8",
+                "reference": "4f368e317921f580a455adc3b95b3423e53ea8e8",
                 "shasum": ""
             },
             "require": {
@@ -974,16 +877,9 @@
                 "php": ">=5.3.10"
             },
             "require-dev": {
-                "joomla/test": "~1.0",
-                "phpunit/phpunit": "4.*",
-                "squizlabs/php_codesniffer": "1.*"
+                "joomla/test": "~1.0"
             },
             "type": "joomla-package",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Joomla\\View\\": "src/",
@@ -1001,7 +897,7 @@
                 "joomla",
                 "view"
             ],
-            "time": "2014-09-01 02:30:31"
+            "time": "2014-02-09 07:07:32"
         },
         {
             "name": "league/di",
@@ -1055,24 +951,19 @@
         },
         {
             "name": "psr/log",
-            "version": "dev-master",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "a78d6504ff5d4367497785ab2ade91db3a9fbe11"
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/a78d6504ff5d4367497785ab2ade91db3a9fbe11",
-                "reference": "a78d6504ff5d4367497785ab2ade91db3a9fbe11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
                 "shasum": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-0": {
                     "Psr\\Log\\": ""
@@ -1094,7 +985,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2014-01-18 15:33:09"
+            "time": "2012-12-21 11:40:51"
         },
         {
             "name": "symfony/http-foundation",
@@ -1203,10 +1094,8 @@
     ],
     "packages-dev": [],
     "aliases": [],
-    "minimum-stability": "dev",
-    "stability-flags": {
-        "symfony/http-foundation": 0
-    },
+    "minimum-stability": "stable",
+    "stability-flags": [],
     "prefer-stable": false,
     "platform": {
         "php": ">=5.3.10"

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,364 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "04507558e7e991a7ee914d2c82eac606",
+    "packages": [
+        {
+            "name": "filp/whoops",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/filp/whoops.git",
+                "reference": "6ad204c4280b0f178ab903047cb684ce66c4954b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/6ad204c4280b0f178ab903047cb684ce66c4954b",
+                "reference": "6ad204c4280b0f178ab903047cb684ce66c4954b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "0.9.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Whoops": "src/"
+                },
+                "classmap": [
+                    "src/deprecated"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Filipe Dobreira",
+                    "homepage": "https://github.com/filp",
+                    "role": "Developer"
+                }
+            ],
+            "description": "php error handling for cool kids",
+            "homepage": "https://github.com/filp/whoops",
+            "keywords": [
+                "error",
+                "exception",
+                "handling",
+                "library",
+                "silex-provider",
+                "whoops",
+                "zf2"
+            ],
+            "time": "2014-08-28 17:38:36"
+        },
+        {
+            "name": "joomla/framework",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla/joomla-framework.git",
+                "reference": "c1be2eb75c38533a25d0106d3d381c8e6b228eb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla/joomla-framework/zipball/c1be2eb75c38533a25d0106d3d381c8e6b228eb6",
+                "reference": "c1be2eb75c38533a25d0106d3d381c8e6b228eb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.10",
+                "psr/log": "~1.0"
+            },
+            "replace": {
+                "joomla/application": "self.version",
+                "joomla/archive": "self.version",
+                "joomla/cache": "self.version",
+                "joomla/compat": "self.version",
+                "joomla/controller": "self.version",
+                "joomla/crypt": "self.version",
+                "joomla/data": "self.version",
+                "joomla/database": "self.version",
+                "joomla/date": "self.version",
+                "joomla/facebook": "self.version",
+                "joomla/filesystem": "self.version",
+                "joomla/filter": "self.version",
+                "joomla/form": "self.version",
+                "joomla/github": "self.version",
+                "joomla/google": "self.version",
+                "joomla/http": "self.version",
+                "joomla/image": "self.version",
+                "joomla/input": "self.version",
+                "joomla/keychain": "self.version",
+                "joomla/language": "self.version",
+                "joomla/linkedin": "self.version",
+                "joomla/log": "self.version",
+                "joomla/model": "self.version",
+                "joomla/oauth1": "self.version",
+                "joomla/oauth2": "self.version",
+                "joomla/profiler": "self.version",
+                "joomla/registry": "self.version",
+                "joomla/router": "self.version",
+                "joomla/session": "self.version",
+                "joomla/string": "self.version",
+                "joomla/test": "self.version",
+                "joomla/twitter": "self.version",
+                "joomla/uri": "self.version",
+                "joomla/utilities": "self.version",
+                "joomla/view": "self.version"
+            },
+            "require-dev": {
+                "symfony/yaml": "~2.0"
+            },
+            "suggest": {
+                "symfony/yaml": "Install symfony/yaml 2.* if you require YAML support."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Joomla": "src/",
+                    "Psr": "vendor/psr/cache"
+                },
+                "classmap": [
+                    "src/Joomla/Compat/JsonSerializable.php"
+                ],
+                "files": [
+                    "src/Joomla/PHP/methods.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "The Joomla Framework is a platform for writing Web and command line applications in PHP.",
+            "homepage": "https://github.com/joomla/joomla-framework",
+            "keywords": [
+                "framework",
+                "joomla"
+            ],
+            "time": "2014-04-26 00:07:56"
+        },
+        {
+            "name": "league/di",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/di.git",
+                "reference": "ad0259589949f12abeae6c1e918a0ff7ef00b00a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/di/zipball/ad0259589949f12abeae6c1e918a0ff7ef00b00a",
+                "reference": "ad0259589949f12abeae6c1e918a0ff7ef00b00a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "league/phpunit-coverage-listener": "~1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "League\\Di\\": [
+                        "src/",
+                        "test/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Don Gilbert",
+                    "email": "don@dongilbert.net",
+                    "homepage": "http://dongilbert.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Fast Dependency Injection Container for PHP 5.3+",
+            "homepage": "https://github.com/php-loep/di",
+            "keywords": [
+                "dependency injection",
+                "dic",
+                "ioc"
+            ],
+            "time": "2013-08-04 22:55:53"
+        },
+        {
+            "name": "psr/log",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "a78d6504ff5d4367497785ab2ade91db3a9fbe11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/a78d6504ff5d4367497785ab2ade91db3a9fbe11",
+                "reference": "a78d6504ff5d4367497785ab2ade91db3a9fbe11",
+                "shasum": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Psr\\Log\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2014-01-18 15:33:09"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v2.3.19",
+            "target-dir": "Symfony/Component/HttpFoundation",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/HttpFoundation.git",
+                "reference": "d0125fed988da9e189864c2e6de967b3ee7f1d98"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/d0125fed988da9e189864c2e6de967b3ee7f1d98",
+                "reference": "d0125fed988da9e189864c2e6de967b3ee7f1d98",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "classmap": [
+                    "Symfony/Component/HttpFoundation/Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony HttpFoundation Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-09-03 07:39:11"
+        },
+        {
+            "name": "tracy/tracy",
+            "version": "v2.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/tracy.git",
+                "reference": "97889d2b8cfb7607cc370ca0ddb97c6f5b43deb9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/tracy/zipball/97889d2b8cfb7607cc370ca0ddb97c6f5b43deb9",
+                "reference": "97889d2b8cfb7607cc370ca0ddb97c6f5b43deb9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1"
+            },
+            "require-dev": {
+                "nette/tester": "~1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/Tracy"
+                ],
+                "files": [
+                    "src/shortcuts.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "http://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "http://nette.org/contributors"
+                }
+            ],
+            "description": "Tracy: useful PHP debugger",
+            "homepage": "http://tracy.nette.org",
+            "keywords": [
+                "debug",
+                "debugger",
+                "nette"
+            ],
+            "time": "2014-08-24 23:36:30"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": {
+        "joomla/framework": 20,
+        "joomla/database": 20,
+        "symfony/http-foundation": 0
+    },
+    "prefer-stable": false,
+    "platform": {
+        "php": ">=5.3.10"
+    },
+    "platform-dev": []
+}

--- a/install/model/install.php
+++ b/install/model/install.php
@@ -130,7 +130,14 @@ class crmInstallModel
             $this->options
         );
 
-        $schema = JPATH_BASE."/install/sql/".$this->config->dbtype."/joomla.sql";
+	    $dbtype = $this->config->dbtype;
+
+	    if ($dbtype == 'mysqli')
+	    {
+		    $dbtype = 'mysql';
+	    }
+
+        $schema = JPATH_BASE."/install/sql/".$dbtype."/joomla.sql";
 
         // Get the contents of the schema file.
         if (!($buffer = file_get_contents($schema)))


### PR DESCRIPTION
This will update the Framework code to pull from the packages independently versus the dated root `joomla/framework` repository and will require stable versions of all packages.

I also added a check in the installer for MySQLi to just use the MySQL schema since I was getting a file not found error doing a quick test.
