### PR TITLE
Modify how version is set and retrieved

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,7 +10,7 @@ if (version_compare(PHP_VERSION, '5.3.10', '<')) {
 	die('Your host needs to use PHP 5.3.10 or higher to run this version of Cobalt!');
 }
 
-const _CEXEC = 1;
+define('_CEXEC', 1);
 
 require_once __DIR__ . '/src/boot.php';
 

--- a/src/Cobalt/Helper/ConfigHelper.php
+++ b/src/Cobalt/Helper/ConfigHelper.php
@@ -54,17 +54,7 @@ class ConfigHelper
 
     public static function getVersion()
     {
-        $xml = JFactory::getXML( 'simple' );
-
-         if ( file_exists(JPATH_SITE.'/administrator/cobalt.xml')) {
-             $xml->loadFile( JPATH_SITE.'/administrator/cobalt.xml' );
-            $position = $xml->document->getElementByPath(  'version' );
-
-            return $position->data();
-         } else {
-             return 0;
-         }
-
+	    return COBALT_VERSION;
     }
 
     public static function getNamingConventions()

--- a/src/defines.php
+++ b/src/defines.php
@@ -8,6 +8,16 @@
 
 defined('_CEXEC') or die;
 
+/*
+ * Define Cobalt's version number here, update this at release time
+ *
+ * Always ensure -dev is appended while in development between releases
+ * and that the base version number is the next planned release.
+ *
+ * i.e.  If 1.0.0 was released, this should be 1.0.1-dev
+ */
+define('COBALT_VERSION', '1.0.0-dev');
+
 // Cobalt Application defines.
 define('JPATH_ROOT',          dirname(__DIR__));
 define('JPATH_BASE',          JPATH_ROOT);


### PR DESCRIPTION
The current getVersion method refers to a file that doesn't appear to exist in the repo's history.  So, I've defined the version number via constant.

Doing it this way also enables the packaging scripts to read the version number.
