### PR TITLE
Use Joomla\DI in place of League\DI

### DIFF
--- a/build/package_devhead.php
+++ b/build/package_devhead.php
@@ -90,6 +90,15 @@ system('rm vendor/joomla/date/composer.json');
 system('rm vendor/joomla/date/phpunit.*');
 system('rm vendor/joomla/date/README.md');
 
+// joomla/di
+system('rm -rf vendor/joomla/di/.travis');
+system('rm -rf vendor/joomla/di/docs');
+system('rm -rf vendor/joomla/di/Tests');
+system('rm vendor/joomla/di/.travis.yml');
+system('rm vendor/joomla/di/composer.json');
+system('rm vendor/joomla/di/phpunit.*');
+system('rm vendor/joomla/di/README.md');
+
 // joomla/event
 system('rm -rf vendor/joomla/event/.travis');
 system('rm -rf vendor/joomla/event/Tests');
@@ -224,15 +233,6 @@ system('rm vendor/joomla/view/.travis.yml');
 system('rm vendor/joomla/view/composer.json');
 system('rm vendor/joomla/view/phpunit.*');
 system('rm vendor/joomla/view/README.md');
-
-// league/di
-system('rm -rf vendor/league/di/test');
-system('rm vendor/league/di/.gitignore');
-system('rm vendor/league/di/.travis.yml');
-system('rm vendor/league/di/composer.json');
-system('rm vendor/league/di/CONTRIBUTING.md');
-system('rm vendor/league/di/phpunit.xml.dist');
-system('rm vendor/league/di/README.md');
 
 // psr/log
 system('rm -rf vendor/psr/log/Psr/Log/Test');

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
 		"joomla/crypt": "~1.1",
 		"joomla/database": "~1.1",
 		"joomla/date": "~1.1",
+		"joomla/di": "~1.2",
 		"joomla/event": "~1.1",
 		"joomla/filesystem": "~1.1",
 		"joomla/filter": "~1.1",
@@ -21,7 +22,6 @@
 		"joomla/string": "~1.2",
 		"joomla/view": "~1.1",
 		"symfony/http-foundation": "2.3.*",
-		"league/di": "1.*",
 		"filp/whoops": "1.*",
 		"tracy/tracy": "2.2.3"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f230f9ea17c9774ccd07461968a749b1",
+    "hash": "bf75b30a68aa5b821e758338db181c2f",
     "packages": [
         {
             "name": "filp/whoops",
@@ -306,6 +306,46 @@
                 "joomla"
             ],
             "time": "2014-02-09 01:27:57"
+        },
+        {
+            "name": "joomla/di",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/di.git",
+                "reference": "4866c58e92ce4e851cd87d5d9d31b069b7284267"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/di/zipball/4866c58e92ce4e851cd87d5d9d31b069b7284267",
+                "reference": "4866c58e92ce4e851cd87d5d9d31b069b7284267",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.10"
+            },
+            "type": "joomla-package",
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\DI\\": "src/",
+                    "Joomla\\DI\\Tests\\": "Tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla DI Package",
+            "homepage": "https://github.com/joomla-framework/di",
+            "keywords": [
+                "container",
+                "dependency injection",
+                "di",
+                "framework",
+                "ioc",
+                "joomla"
+            ],
+            "time": "2014-03-21 13:20:34"
         },
         {
             "name": "joomla/event",
@@ -898,56 +938,6 @@
                 "view"
             ],
             "time": "2014-02-09 07:07:32"
-        },
-        {
-            "name": "league/di",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/di.git",
-                "reference": "ad0259589949f12abeae6c1e918a0ff7ef00b00a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/di/zipball/ad0259589949f12abeae6c1e918a0ff7ef00b00a",
-                "reference": "ad0259589949f12abeae6c1e918a0ff7ef00b00a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "league/phpunit-coverage-listener": "~1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "League\\Di\\": [
-                        "src/",
-                        "test/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Don Gilbert",
-                    "email": "don@dongilbert.net",
-                    "homepage": "http://dongilbert.net",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Fast Dependency Injection Container for PHP 5.3+",
-            "homepage": "https://github.com/php-loep/di",
-            "keywords": [
-                "dependency injection",
-                "dic",
-                "ioc"
-            ],
-            "time": "2013-08-04 22:55:53"
         },
         {
             "name": "psr/log",

--- a/index.php
+++ b/index.php
@@ -18,4 +18,4 @@ use Tracy\Debugger;
 Debugger::enable();
 
 // $container is setup in the previous require.
-$container->resolve('app')->execute();
+$container->get('app')->execute();

--- a/libraries/modular/authenticate/authenticate.php
+++ b/libraries/modular/authenticate/authenticate.php
@@ -36,7 +36,7 @@ class ModularAuthenticate
      */
     public function login($credentials, $options = array())
     {
-        $app = Container::get('app');
+        $app = Container::fetch('app');
 
         // Get the global JAuthentication object.
         jimport('joomla.user.authentication');

--- a/src/Cobalt/Container.php
+++ b/src/Cobalt/Container.php
@@ -4,22 +4,11 @@ namespace Cobalt;
 
 defined('_CEXEC') or die;
 
-use League\Di\Container as LeagueContainer;
+use Joomla\DI\Container as JoomlaContainer;
 
-class Container extends LeagueContainer
+class Container extends JoomlaContainer
 {
     protected static $instance;
-
-    protected $aliases = array();
-
-    protected $providers = array();
-
-    public function alias($alias, $binding)
-    {
-        $this->aliases[$alias] = $binding;
-
-        return $this;
-    }
 
     /**
      * @return Container
@@ -33,32 +22,8 @@ class Container extends LeagueContainer
         return self::$instance;
     }
 
-    public static function get($key)
+    public static function fetch($key)
     {
-        return self::getInstance()->resolve($key);
-    }
-
-    public function registerServiceProvider(Provider\ServiceProviderInterface $provider)
-    {
-        $this->providers[] = $provider;
-
-        return $this;
-    }
-
-    public function registerProviders()
-    {
-        foreach ($this->providers as $provider) {
-            /** @var \Cobalt\Provider\ServiceProviderInterface $provider */
-            $provider->register($this);
-        }
-    }
-
-    public function resolve($binding)
-    {
-        if (isset($this->aliases[$binding])) {
-            $binding = $this->aliases[$binding];
-        }
-
-        return parent::resolve($binding);
+        return self::getInstance()->get($key);
     }
 }

--- a/src/Cobalt/Controller/DefaultController.php
+++ b/src/Cobalt/Controller/DefaultController.php
@@ -94,7 +94,7 @@ class DefaultController extends AbstractController
     {
         $fqcn = 'Cobalt\\Model\\' . $modelName;
 
-        return $this->container->build($fqcn);
+        return $this->container->buildObject($fqcn);
     }
 
     public function isAjaxRequest()

--- a/src/Cobalt/Helper/ActivityHelper.php
+++ b/src/Cobalt/Helper/ActivityHelper.php
@@ -19,7 +19,7 @@ class ActivityHelper
 
     public static function saveActivity($old_info, $new_info, $model, $action_type)
     {
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
         $user_id = UsersHelper::getUserId();
         $date = DateHelper::formatDBDate(date('Y-m-d H:i:s'));
@@ -65,7 +65,7 @@ class ActivityHelper
 
     public static function saveUserLoginHistory()
     {
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $user_id = UsersHelper::getUserId();
@@ -91,7 +91,7 @@ class ActivityHelper
 
     public static function getActivity()
     {
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $query->select('h.*, CONCAT(u.first_name," ", u.last_name) AS owner_name, c.name as company_name, CONCAT(p.first_name," ", p.last_name) AS person_name,
@@ -145,7 +145,7 @@ class ActivityHelper
         $query->order('h.date DESC');
 
         if (self::$limit != null) {
-            $query .= " LIMIT ".$this->limit;
+            $query .= " LIMIT ".self::$limit;
         } else {
             $query .= " LIMIT 10";
         }

--- a/src/Cobalt/Helper/CobaltHelper.php
+++ b/src/Cobalt/Helper/CobaltHelper.php
@@ -45,7 +45,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
      */
     public static function getTaskTemplates($type,$id=null)
     {
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
         $query->select("t.*")->from("#__templates AS t")->where("t.type=".$db->quote($type));
         $db->setQuery($query);
@@ -77,7 +77,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function storeCustomCf($id,$cf_data,$type)
     {
         //Get DBO
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //date generation
@@ -124,7 +124,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
 
     public static function checkEmailName($email)
     {
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(TRUE);
 
         $query->select("email")
@@ -179,13 +179,13 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
 
     public static function shareItem($itemId=null,$itemType=null,$userId=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         $itemId = $itemId ? $itemId : $app->input->get('item_id');
         $itemType = $itemType ? $itemType : $app->input->get('item_type');
         $userId = $userId ? $userId : $app->input->get('user_id');
 
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $query->insert("#__shared")
@@ -200,13 +200,13 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
 
     public static function unshareItem($itemId=null,$itemType=null,$userId=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         $itemId = $itemId ? $itemId : $app->input->get('item_id');
         $itemType = $itemType ? $itemType : $app->input->get('item_type');
         $userId = $userId ? $userId : $app->input->get('user_id');
 
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $query->delete("#__shared")
@@ -222,7 +222,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
 
     public static function showShareDialog()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         $document = $app->getDocument();
         $document->addScriptDeclaration('var users='.json_encode(UsersHelper::getAllSharedUsers()).';');
@@ -258,11 +258,11 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
 
     public static function getAssociationName($associationType=null,$associationId=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $associationType = $associationType ? $associationType : $app->input->get('association_type');
         $associationId = $associationId ? $associationId : $app->input->get('association_id');
 
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         switch ($associationType) {

--- a/src/Cobalt/Helper/CompanyHelper.php
+++ b/src/Cobalt/Helper/CompanyHelper.php
@@ -21,7 +21,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getCompany($id)
     {
         //get db object
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //generate query
@@ -67,7 +67,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getSelectedColumnFilters()
     {
         //get the user session data
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $query->select("companies_columns");

--- a/src/Cobalt/Helper/ConfigHelper.php
+++ b/src/Cobalt/Helper/ConfigHelper.php
@@ -21,7 +21,7 @@ class ConfigHelper
 {
      public static function getImapConfig()
      {
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
         $query->select("imap_host,imap_pass,imap_user")->from("#__config")->where("id=1");
         $db->setQuery($query);
@@ -59,7 +59,7 @@ class ConfigHelper
 
     public static function getNamingConventions()
     {
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
         $query->select("lang_deal,lang_person,lang_company,lang_contact,lang_lead,lang_task,lang_event,lang_goal")
                 ->from("#__config")

--- a/src/Cobalt/Helper/DateHelper.php
+++ b/src/Cobalt/Helper/DateHelper.php
@@ -186,7 +186,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
 
     public static function getSiteTimezone()
     {
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
         $query->select("timezone")->from("#__config")->where("id=1");
         $db->setQuery($query);

--- a/src/Cobalt/Helper/DealHelper.php
+++ b/src/Cobalt/Helper/DealHelper.php
@@ -22,7 +22,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getDeal($id)
     {
         //get db object
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //generate query
@@ -55,7 +55,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getStages($stage_name=null,$stagesOnly=FALSE,$idsOnly=TRUE)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //query
@@ -93,7 +93,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getNonInactiveStages()
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //query
@@ -110,7 +110,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
 
     public static function getPrimaryContact($deal_id)
     {
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
         $query->select("primary_contact_id")->from("#__deals")->where("id=".$deal_id);
         $db->setQuery($query);
@@ -122,7 +122,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getSourceStages()
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //query
@@ -153,7 +153,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getActiveStages($idsOnly=FALSE)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //query
@@ -186,7 +186,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getGoalStages()
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //query
@@ -245,7 +245,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getWonStages()
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //search for 100% stage id
@@ -264,7 +264,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getInactiveStages()
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //search for 0% stage id
@@ -282,7 +282,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getClosedStages()
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //search for 100% stage id
@@ -304,7 +304,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getStatuses($status_name=null,$classOnly=FALSE)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //query
@@ -345,7 +345,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getSources($source_name=null)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //query
@@ -373,7 +373,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getUserCustomFields($id=null)
     {
         //get dbo
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //gen query string
@@ -451,7 +451,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getSelectedColumnFilters()
     {
         //get the user session data
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $query->select("deals_columns");

--- a/src/Cobalt/Helper/DocumentHelper.php
+++ b/src/Cobalt/Helper/DocumentHelper.php
@@ -22,7 +22,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getTotalDocuments()
     {
         //db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //select

--- a/src/Cobalt/Helper/DropdownHelper.php
+++ b/src/Cobalt/Helper/DropdownHelper.php
@@ -26,7 +26,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
          $html = '';
 
         //grab db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
 
         //generate query based on type
          $query = $db->getQuery(true);
@@ -204,7 +204,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
              $return = array();
 
             //grab db
-            $db = \Cobalt\Container::get('db');
+            $db = \Cobalt\Container::fetch('db');
 
             //generate query based on type
              $query = $db->getQuery(true);
@@ -248,7 +248,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
         public static function getCustomData($id,$type)
         {
             //get dbo
-            $db = \Cobalt\Container::get('db');
+            $db = \Cobalt\Container::fetch('db');
             $query = $db->getQuery(true);
 
             //query
@@ -275,7 +275,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
          */
         public static function getCustomValue($customType,$customNameOrId,$customValue,$itemId)
         {
-            $db = \Cobalt\Container::get('db');
+            $db = \Cobalt\Container::fetch('db');
             $query = $db->getQuery(true);
 
             $id = str_replace("custom_","",$customNameOrId);
@@ -326,7 +326,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
         public static function getLeaderBoards()
         {
             //load database
-            $db = \Cobalt\Container::get('db');
+            $db = \Cobalt\Container::fetch('db');
             $query = $db->getQuery(true);
 
             //load goals associate with user depending on team//role that have a leaderboard flag in the database
@@ -447,7 +447,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
         public static function getTeams($team=null)
         {
             //get database
-            $db = \Cobalt\Container::get('db');
+            $db = \Cobalt\Container::fetch('db');
             $query = $db->getQuery(true);
             //query string
             //u.id//
@@ -475,7 +475,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
         public static function getManagers($remove=null)
         {
             //get database
-            $db = \Cobalt\Container::get('db');
+            $db = \Cobalt\Container::fetch('db');
             $query = $db->getQuery(true);
             //query string
             $query->select("u.id,u.first_name,u.last_name,u.team_id");
@@ -655,7 +655,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
 
          public static function generateDealStatuses($selected=null, $name="status_id", $class="class='inputbox form-control'")
          {
-            $db = \Cobalt\Container::get('db');
+            $db = \Cobalt\Container::fetch('db');
             $query = $db->getQuery(true);
             $query->select("id,name")->from("#__deal_status");
 

--- a/src/Cobalt/Helper/EventHelper.php
+++ b/src/Cobalt/Helper/EventHelper.php
@@ -22,7 +22,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getCategories($appendLanguage=FALSE)
     {
         //grab db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
 
         //generate query
         $query = $db->getQuery(true);

--- a/src/Cobalt/Helper/MailinglistsHelper.php
+++ b/src/Cobalt/Helper/MailinglistsHelper.php
@@ -25,7 +25,7 @@ class MailinglistsHelper
 
     public function __construct()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $this->listId = $app->input->get('list_id');
         $this->peopleIds = $app->input->get('people_ids');
         $this->subscriber = $this->getSubscriberId();
@@ -33,13 +33,13 @@ class MailinglistsHelper
 
     public static function getSubscriberId()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         $person_id = $app->input->get('person_id') ? $app->input->get('person_id') : $app->input->get('id');
         $personModel = new PeopleModel;
         $email = $personModel->getEmail($person_id);
 
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $query->select("subid")
@@ -62,7 +62,7 @@ class MailinglistsHelper
     public static function getMailingLists($all=FALSE)
     {
         $subid = self::getSubscriberId();
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $query->select("DISTINCT list.listid,list.name,list.description,list.color")
@@ -102,10 +102,10 @@ class MailinglistsHelper
      */
     public static function getNewsletters($listId=NULL)
     {
-        $listId = $listId ? $listId : $this->listId;
+        $listId = $listId ? $listId : static::$listId;
         $subId = self::getSubscriberId();
 
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $query->select("mail.mailid,mail.subject,mail.published,mail.senddate,user.open,user.opendate")
@@ -132,7 +132,7 @@ class MailinglistsHelper
         $person_id = $data['person_id'];
         $listid = $data['listid'];
 
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $peopleModel = new PeopleModel;
@@ -192,7 +192,7 @@ class MailinglistsHelper
         $person_id = $data['person_id'];
         $listid = $data['listid'];
 
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $time = time();
@@ -209,14 +209,14 @@ class MailinglistsHelper
 
     public static function getLinks()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         $data = $app->input->getRequest('post');
         $person_id = array_key_exists('person_id',$data) ? $data['person_id'] : $data['id'];
         $mailid = $data['mailid'];
         $subid = self::getSubscriberId();
 
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $query->select("click.click,url.name,url.url")

--- a/src/Cobalt/Helper/MenuHelper.php
+++ b/src/Cobalt/Helper/MenuHelper.php
@@ -310,7 +310,7 @@ public static function getHelpMenuLinks()
     {
         $modules = array();
 
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         /** Side menu links **/
         $menu_links = MenuHelper::getMenuLinks();

--- a/src/Cobalt/Helper/NoteHelper.php
+++ b/src/Cobalt/Helper/NoteHelper.php
@@ -22,7 +22,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getCategories()
     {
         //grab db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
 
         //generate query
         $query = $db->getQuery(true);

--- a/src/Cobalt/Helper/PeopleHelper.php
+++ b/src/Cobalt/Helper/PeopleHelper.php
@@ -22,7 +22,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getPerson($id)
     {
         //get db object
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //generate query
@@ -42,7 +42,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getStatusList($idsOnly = FALSE)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //select statuses from db
@@ -61,7 +61,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getTagList()
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //select statuses from db
@@ -125,7 +125,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
     public static function getSelectedColumnFilters()
     {
         //get the user session data
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $query->select("people_columns");

--- a/src/Cobalt/Helper/StylesHelper.php
+++ b/src/Cobalt/Helper/StylesHelper.php
@@ -21,7 +21,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
  {
         public static function getSiteName()
         {
-            $db = \Cobalt\Container::get('db');
+            $db = \Cobalt\Container::fetch('db');
             $query = $db->getQuery(true);
 
             $query->select("site_name")->from("#__branding")->where("assigned=1");
@@ -36,7 +36,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
 
         public static function getSiteLogo()
         {
-            $db = \Cobalt\Container::get('db');
+            $db = \Cobalt\Container::fetch('db');
             $query = $db->getQuery(true);
 
             $query->select("site_logo")->from("#__branding")->where("assigned=1");
@@ -58,7 +58,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
         public static function getDynamicStyle()
         {
             //database
-            $db = \Cobalt\Container::get('db');
+            $db = \Cobalt\Container::fetch('db');
             $query = $db->getQuery(true);
 
             //query
@@ -91,7 +91,7 @@ defined( '_CEXEC' ) or die( 'Restricted access' );
         //load all styles
         public static function loadStyleSheets()
         {
-            $app = \Cobalt\Container::get('app');
+            $app = \Cobalt\Container::fetch('app');
             $document = $app->getDocument();
 
             $view = $app->input->get('view');

--- a/src/Cobalt/Helper/TemplateHelper.php
+++ b/src/Cobalt/Helper/TemplateHelper.php
@@ -77,7 +77,7 @@ class TemplateHelper
 
     public static function endCompWrap()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         if (self::isMobile()) {
 
@@ -138,7 +138,7 @@ class TemplateHelper
 
     public static function loadToolbar()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //load menu
         $menu_model = new MenuModel;
@@ -225,7 +225,7 @@ class TemplateHelper
 
     public static function loadReportMenu()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $activeLayout = $app->input->get('layout');
 
         $layouts = array('dashboard','sales_pipeline','source_report','roi_report','deal_milestones','notes','custom_reports');
@@ -275,7 +275,7 @@ class TemplateHelper
     public static function isMobile()
     {
         return false;
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $mobile_detect = new MobileHelper();
         $mobile_auto = $mobile_detect->isMobile();
         $mobile_manual = $app->input->get('mobile');

--- a/src/Cobalt/Helper/ToolbarHelper.php
+++ b/src/Cobalt/Helper/ToolbarHelper.php
@@ -55,7 +55,7 @@ abstract class ToolbarHelper
 
         $html = '<div class="pagetitle ' . htmlspecialchars(implode(' ', $icons)) . '"><h2>' . $title . '</h2></div>';
 
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $app->JComponentTitle = $html;
     }
 

--- a/src/Cobalt/Helper/TranscriptlistsHelper.php
+++ b/src/Cobalt/Helper/TranscriptlistsHelper.php
@@ -19,7 +19,7 @@ class TranscriptlistsHelper
 {
     public static function getRooms($associationId=null,$associationType=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         $autoId = $app->input->get('id') ? $app->input->get('id') : $app->input->get('association_id');
         $autoType = $app->input->get('layout') ? $app->input->get('layout') : $app->input->get('association_type');
@@ -27,7 +27,7 @@ class TranscriptlistsHelper
         $associationId = $associationId ? $associationId : $autoId;
         $associationType = $associationType ? $associationType : $autoType;
 
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $query->select("id,name")
@@ -45,11 +45,11 @@ class TranscriptlistsHelper
 
     public static function getTranscripts($roomId=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         $roomId = $roomId ? $roomId : $app->input->get('room_id');
 
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $query->select("t.*,r.name AS room_name")

--- a/src/Cobalt/Helper/UsersHelper.php
+++ b/src/Cobalt/Helper/UsersHelper.php
@@ -30,7 +30,7 @@ class UsersHelper
         if ($user_role != 'basic') {
 
             //get db
-            $db = \Cobalt\Container::get('db');
+            $db = \Cobalt\Container::fetch('db');
             $query = $db->getQuery(true);
 
             $select = ( $idsOnly ) ? "id AS value,CONCAT(first_name,' ',last_name) AS label" : "*";
@@ -74,7 +74,7 @@ class UsersHelper
     {
         $id = $id ? $id : self::getLoggedInUser()->id;
 
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
         $query->clear()->select("first_name")->from("#__users")->where("id=".$id);
         $db->setQuery($query);
@@ -92,7 +92,7 @@ class UsersHelper
         $results = array();
 
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //get users
@@ -127,7 +127,7 @@ class UsersHelper
         }
 
         //get dbo
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //query
@@ -158,7 +158,7 @@ class UsersHelper
     //return current logged in Cobalt user ID based on Joomla Id
     public static function getUserId()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         return $app->getUser()->get('id');
     }
 
@@ -166,7 +166,7 @@ class UsersHelper
     public static function getRole($user_id=null)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //logged in user
@@ -189,7 +189,7 @@ class UsersHelper
     public static function getTeamId($user_id=null)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $user_id = $user_id ?: UsersHelper::getUserId();
@@ -211,7 +211,7 @@ class UsersHelper
     public static function getTeams($id=null)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //query
@@ -245,7 +245,7 @@ class UsersHelper
     public static function getTeamUsers($id=null,$idsOnly=FALSE)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         if ($idsOnly) {
@@ -273,7 +273,7 @@ class UsersHelper
 
     public static function getAllSharedUsers()
     {
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $query->select("id AS value,CONCAT(first_name,' ',last_name) AS label")
@@ -297,7 +297,7 @@ class UsersHelper
 
     public static function getItemSharedUsers($itemId, $itemType)
     {
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $query->select("s.user_id AS value, CONCAT(u.first_name, ' ', u.last_name) AS label")
@@ -323,7 +323,7 @@ class UsersHelper
     public static function getDealCount($id,$team,$role)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //query
@@ -357,7 +357,7 @@ class UsersHelper
     public static function getPeopleCount($id=null,$team=null,$role=null)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         if (!$id) {
@@ -402,7 +402,7 @@ class UsersHelper
     public static function getPeopleEmails($id=null)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         if (!$id) {
@@ -439,7 +439,7 @@ class UsersHelper
     public static function getCompanyCount($id,$team,$role)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //query
@@ -474,7 +474,7 @@ class UsersHelper
     public static function getCommissionRate($id=null)
     {
        //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //logged in user
@@ -506,7 +506,7 @@ class UsersHelper
     public static function getDateFormat($php=TRUE)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //logged in user
@@ -535,7 +535,7 @@ class UsersHelper
     public static function getTimeFormat($id=null)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //logged in user
@@ -561,7 +561,7 @@ class UsersHelper
     public static function getTimezone($id=null)
     {
         //get db
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         //logged in user
@@ -582,7 +582,7 @@ class UsersHelper
 
     public static function getLoggedInUser()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $user = $app->getUser();
 
         if ($user->get('id'))
@@ -596,7 +596,7 @@ class UsersHelper
 
     public static function getUser($user_id,$array=FALSE)
     {
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
 
         $query = $db->getQuery(true);
         $query->select('c.*');
@@ -616,7 +616,7 @@ class UsersHelper
     /** Determine if logged in user ( or specified user ) is an administrator **/
     public static function isAdmin($user_id=null)
     {
-        $db = \Cobalt\Container::get('db');
+        $db = \Cobalt\Container::fetch('db');
         $query = $db->getQuery(true);
 
         $user_id = $user_id ? $user_id : UsersHelper::getUserId();
@@ -639,7 +639,7 @@ class UsersHelper
     /** Determine if logged in user ( or specified user ) can delete items **/
     public static function canDelete($user_id=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $user = $app->getUser($user_id);
 
         return ( $user->admin == 1 || $user->can_delete == 1 );
@@ -649,7 +649,7 @@ class UsersHelper
      /** Determine if logged in user ( or specified user ) can export items **/
     public static function canExport($user_id = null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $user = $app->getUser($user_id);
 
         return ( $user->exports == 1 || $user->admin == 1 );
@@ -659,7 +659,7 @@ class UsersHelper
     public static function authenticateAdmin()
     {
         if (!self::isAdmin()) {
-            $app = \Cobalt\Container::get('app');
+            $app = \Cobalt\Container::fetch('app');
             $app->redirect('index.php');
         }
     }
@@ -671,7 +671,7 @@ class UsersHelper
 
         if ($userId > 0) {
 
-            $db = \Cobalt\Container::get('db');
+            $db = \Cobalt\Container::fetch('db');
             $query = $db->getQuery(true);
 
             $query->select("language")->from("#__users")->where('id='.$userId);

--- a/src/Cobalt/Helper/ViewHelper.php
+++ b/src/Cobalt/Helper/ViewHelper.php
@@ -12,7 +12,7 @@ class ViewHelper
     public static function getView($viewName, $layoutName='default', $viewFormat='html', $vars=null)
     {
         // Get the application
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         $document = $app->getDocument();
         $app->input->set('view', $viewName);
@@ -58,6 +58,6 @@ class ViewHelper
     {
         $fqcn = 'Cobalt\\Model\\' . $modelName;
 
-        return \Cobalt\Container::getInstance()->build($fqcn);
+        return \Cobalt\Container::getInstance()->buildObject($fqcn);
     }
 }

--- a/src/Cobalt/Model/Branding.php
+++ b/src/Cobalt/Model/Branding.php
@@ -23,7 +23,7 @@ class Branding extends DefaultModel
     public function store()
     {
         //Load Tables
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $row = new BrandingTable;
         $data = $app->input->getRequest('post');
 

--- a/src/Cobalt/Model/Categories.php
+++ b/src/Cobalt/Model/Categories.php
@@ -23,7 +23,7 @@ class Categories extends DefaultModel
     public function store()
     {
         //Load Tables
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $row = new CategoriesTable;
         $data = $app->input->getRequest('post');
 
@@ -106,7 +106,7 @@ class Categories extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $filter_order = $app->getUserStateFromRequest('Categories.filter_order','filter_order','c.name');
         $filter_order_Dir = $app->getUserStateFromRequest('Categories.filter_order_Dir','filter_order_Dir','asc');
 

--- a/src/Cobalt/Model/Cobalt.php
+++ b/src/Cobalt/Model/Cobalt.php
@@ -31,7 +31,7 @@ class Cobalt extends AbstractModel
      */
     public function __construct()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         parent::__construct();
         $this->getListLimits();
         $this->view = $app->input->get('view');
@@ -50,7 +50,7 @@ class Cobalt extends AbstractModel
     public function saveorder($pks = null, $order = null)
     {
         // Initialise variables.
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $data = $app->input->getRequest('post');
 
         $tableClass = 'Cobalt\\Table\\' . ucfirst($data['view']) . 'Table';
@@ -149,7 +149,7 @@ class Cobalt extends AbstractModel
 
     public function getListLimits()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         // Get pagination request variables
         $limit = $app->getUserStateFromRequest($this->view.'_limit','limit',10);
@@ -193,7 +193,7 @@ class Cobalt extends AbstractModel
     public function reorder($pks, $delta = 0)
     {
         // Initialise variables.
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $data = $app->input->getRequest('post');
 
         $tableClass = 'Cobalt\\Table\\' . ucfirst($data['view']) . 'Table';

--- a/src/Cobalt/Model/Company.php
+++ b/src/Cobalt/Model/Company.php
@@ -37,7 +37,7 @@ class Company extends DefaultModel
     public function __construct()
     {
         parent::__construct();
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $this->_view = $app->input->get('view');
         $this->_layout = str_replace('_filter','',$app->input->get('layout'));
     }
@@ -49,7 +49,7 @@ class Company extends DefaultModel
      */
     public function store($data=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new CompanyTable;
@@ -126,7 +126,7 @@ class Company extends DefaultModel
      */
     public function _buildQuery()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         $this->db->setQuery("SET SQL_BIG_SELECTS=1")->execute();
 
@@ -285,7 +285,7 @@ class Company extends DefaultModel
      */
     public function getCompanies($id = null, $type = null, $user = null, $team = null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $this->_id = $id;
         $this->_type = $type;
         $this->_user = $user;
@@ -375,7 +375,7 @@ class Company extends DefaultModel
 
     public function getCompany($id = null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $id = $id ? $id : $app->input->get('id');
 
         if ($id > 0) {
@@ -453,7 +453,7 @@ class Company extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //determine view so we set correct states
         $view = $app->input->get('view');

--- a/src/Cobalt/Model/CompanyCustom.php
+++ b/src/Cobalt/Model/CompanyCustom.php
@@ -23,7 +23,7 @@ class CompanyCustom extends DefaultModel
 
     public function store()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new CompanyCustomTable;
@@ -132,7 +132,7 @@ class CompanyCustom extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $filter_order = $app->getUserStateFromRequest('Companycustom.filter_order','filter_order','c.name');
         $filter_order_Dir = $app->getUserStateFromRequest('Companycustom.filter_order_Dir','filter_order_Dir','asc');
 

--- a/src/Cobalt/Model/Config.php
+++ b/src/Cobalt/Model/Config.php
@@ -19,7 +19,7 @@ class Config extends DefaultModel
 {
     public function store($data = null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new ConfigTable;

--- a/src/Cobalt/Model/Conversation.php
+++ b/src/Cobalt/Model/Conversation.php
@@ -31,7 +31,7 @@ class Conversation extends DefaultModel
      */
     public function store()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new ConversationTable;

--- a/src/Cobalt/Model/Deal.php
+++ b/src/Cobalt/Model/Deal.php
@@ -54,7 +54,7 @@ class Deal extends DefaultModel
     public function __construct()
     {
         parent::__construct();
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $this->_view = $this->app->input->get('view');
         $this->_layout = str_replace('_filter','',$this->app->input->get('layout'));
     }
@@ -934,7 +934,7 @@ class Deal extends DefaultModel
     public function getReportDeals()
     {
         //get filter
-        $session = \Cobalt\Container::get('session');
+        $session = $this->app->getSession();
         $filter = $session->get('deal_stage_filter');
         //get deals
         $deals = $this->getDeals(null,null,null,'active');

--- a/src/Cobalt/Model/DealCustom.php
+++ b/src/Cobalt/Model/DealCustom.php
@@ -22,7 +22,7 @@ class DealCustom extends DefaultModel
 
     public function store()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new DealCustomTable;
@@ -132,7 +132,7 @@ class DealCustom extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $filter_order = $app->getUserStateFromRequest('Dealcustom.filter_order','filter_order','c.name');
         $filter_order_Dir = $app->getUserStateFromRequest('Dealcustom.filter_order_Dir','filter_order_Dir','asc');
 

--- a/src/Cobalt/Model/DefaultModel.php
+++ b/src/Cobalt/Model/DefaultModel.php
@@ -33,12 +33,12 @@ class DefaultModel extends AbstractDatabaseModel
     {
         if (is_null($db))
         {
-            $db = Container::get('db');
+            $db = Container::fetch('db');
         }
 
         $this->db = $db;
 
-        $this->app = Container::get('app');
+        $this->app = Container::fetch('app');
 
         parent::__construct($db);
 

--- a/src/Cobalt/Model/Document.php
+++ b/src/Cobalt/Model/Document.php
@@ -183,7 +183,7 @@ class Document extends DefaultModel
             return false;
         }
 
-       $app = \Cobalt\Container::get('app');
+       $app = \Cobalt\Container::fetch('app');
        $app->triggerEvent('onBeforeDocumentSave', array(&$row));
 
         // Make sure the record is valid
@@ -215,7 +215,7 @@ class Document extends DefaultModel
      */
     public function getDocuments($id=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //get DBO
         $db = JFactory::getDBO();
@@ -394,7 +394,7 @@ class Document extends DefaultModel
 
     public function getDocument($id=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         $db = JFactory::getDBO();
         $query = $db->getQuery(true);
@@ -458,7 +458,7 @@ class Document extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         if ( $app->input->get('view') == "documents" ) {
 

--- a/src/Cobalt/Model/Documents.php
+++ b/src/Cobalt/Model/Documents.php
@@ -25,7 +25,7 @@ class Documents extends DefaultModel
 
     public function store($data=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new DocumentsTable;
@@ -110,7 +110,7 @@ class Documents extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $filter_order = $app->getUserStateFromRequest('Documents.filter_order','filter_order','d.filename');
         $filter_order_Dir = $app->getUserStateFromRequest('Documents.filter_order_Dir','filter_order_Dir','asc');
 
@@ -209,7 +209,7 @@ class Documents extends DefaultModel
         //always use constants when making file paths, to avoid the possibilty of remote file inclusion
         $uploadPath = JPATH_SITE.'/uploads/'.$hash;
 
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         if (!File::upload($fileTemp, $uploadPath)) {
             $msg = TextHelper::_('COBALT_DOC_UPLOAD_FAIL');

--- a/src/Cobalt/Model/Event.php
+++ b/src/Cobalt/Model/Event.php
@@ -41,7 +41,7 @@ class Event extends DefaultModel
     public function __construct()
     {
         parent::__construct();
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $this->view = $app->input->get('view');
         $this->layout = $app->input->get('layout','list');
 
@@ -55,7 +55,7 @@ class Event extends DefaultModel
     public function store($data = null)
     {
 
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $db = JFactory::getDBO();
 
         //Load Tables
@@ -192,7 +192,7 @@ class Event extends DefaultModel
      */
     public function getEvents($loc=null,$user=null,$association=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $loc = $loc ? $loc : $this->loc;
 
         $db = JFactory::getDBO();
@@ -808,7 +808,7 @@ class Event extends DefaultModel
      */
     public function getEvent($id=null,$formatTime=true)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //db
         $db = JFactory::getDBO();
@@ -1119,7 +1119,7 @@ class Event extends DefaultModel
      */
     public function removeEvent($id=null,$type=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         $type = ( $type == null ) ? $app->input->get('type') : $type;
         $date = $app->input->get('date');
@@ -1287,7 +1287,7 @@ class Event extends DefaultModel
      */
     public function markComplete()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Determine if we are editing a series of events of a single event
         $event_id = $app->input->get('event_id');
@@ -1371,7 +1371,7 @@ class Event extends DefaultModel
      */
     public function markIncomplete()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Determine if we are editing a series of events of a single event
         $event_id = $app->input->get('event_id');
@@ -1394,7 +1394,7 @@ class Event extends DefaultModel
      */
     public function postponeEvent($days=null,$event_id=null)
     {
-            $app = \Cobalt\Container::get('app');
+            $app = \Cobalt\Container::fetch('app');
 
             $event_id = ( $event_id == null ) ? $app->input->get('event_id') : $event_id;
             $days = ( $days == null ) ? $app->input->get("days") : $days;
@@ -1441,7 +1441,7 @@ class Event extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //determine view so we set correct states
         $view = $this->view;

--- a/src/Cobalt/Model/Export.php
+++ b/src/Cobalt/Model/Export.php
@@ -23,7 +23,7 @@ class Export extends DefaultModel
      */
     public function getCsv()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Determine request type
         $download_type = $app->input->get('list_type');
@@ -43,7 +43,7 @@ class Export extends DefaultModel
      */
     public function getCsvData($data_type)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         $data = array();
 
@@ -123,7 +123,7 @@ class Export extends DefaultModel
      */
     public function getVcard()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         $person_id = $app->input->get('person_id');
 

--- a/src/Cobalt/Model/FormWizard.php
+++ b/src/Cobalt/Model/FormWizard.php
@@ -24,7 +24,7 @@ class FormWizard extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $filter_order = $app->getUserStateFromRequest('Formwizard.filter_order','filter_order','f.name');
         $filter_order_Dir = $app->getUserStateFromRequest('Formwizard.filter_order_Dir','filter_order_Dir','asc');
 
@@ -39,7 +39,7 @@ class FormWizard extends DefaultModel
 
     public function store()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new FormWizardTable;

--- a/src/Cobalt/Model/Goal.php
+++ b/src/Cobalt/Model/Goal.php
@@ -31,7 +31,7 @@ class Goal extends DefaultModel
      */
     public function store()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new GoalTable;

--- a/src/Cobalt/Model/Import.php
+++ b/src/Cobalt/Model/Import.php
@@ -47,7 +47,7 @@ class Import extends DefaultModel
      */
     public function readCSVFile($file, $table = null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         ini_set("auto_detect_line_endings", "1");
         $data = array();
         $line = 1;

--- a/src/Cobalt/Model/Mail.php
+++ b/src/Cobalt/Model/Mail.php
@@ -516,7 +516,7 @@ class Mail extends DefaultModel
     {
         if ( $this->_connect() ) {
             if (!$message_id) {
-                $app = \Cobalt\Container::get('app');
+                $app = \Cobalt\Container::fetch('app');
                 $message_id = $app->input->get('id');
             }
             if ($message_id != null || $message_id != 0) {
@@ -528,7 +528,7 @@ class Mail extends DefaultModel
 
     public function saveEmail($email_id=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         if (!$email_id) {
             $email_id = $app->input->get('id');

--- a/src/Cobalt/Model/Menu.php
+++ b/src/Cobalt/Model/Menu.php
@@ -22,7 +22,7 @@ class Menu extends AbstractModel
 {
     public function store()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new MenuTable;

--- a/src/Cobalt/Model/Note.php
+++ b/src/Cobalt/Model/Note.php
@@ -38,7 +38,7 @@ class Note extends DefaultModel
     public function store($data=null)
     {
 
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new NoteTable;
@@ -195,7 +195,7 @@ class Note extends DefaultModel
      */
     public function getNotes($object_id = NULL,$type = NULL, $display = true)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //grab db
         $db = JFactory::getDBO();
@@ -357,7 +357,7 @@ class Note extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $filter_order = $app->getUserStateFromRequest('Note.filter_order','filter_order','comp.name');
         $filter_order_Dir = $app->getUserStateFromRequest('Note.filter_order_Dir','filter_order_Dir','asc');
 

--- a/src/Cobalt/Model/People.php
+++ b/src/Cobalt/Model/People.php
@@ -49,7 +49,7 @@ class People extends DefaultModel
     {
         parent::__construct();
 
-        $this->app = \Cobalt\Container::get('app');
+        $this->app = \Cobalt\Container::fetch('app');
         $this->_view = $this->app->input->get('view');
         $this->_layout = str_replace('_filter','',$this->app->input->get('layout'));
         $this->_id = $this->app->input->get('id');
@@ -135,7 +135,7 @@ class People extends DefaultModel
             return false;
         }
 
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $app->triggerEvent('onBeforePersonSave', array(&$row));
 
         // Make sure the record is valid
@@ -576,7 +576,7 @@ class People extends DefaultModel
      */
     public function getPerson($id=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $id = $id ? $id : $app->input->get('id');
 
         if ($id > 0) {
@@ -727,7 +727,7 @@ class People extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $view = $this->app->input->get('view');
 
         //TODO add these limits to the switch statement to support multiple pages and layouts

--- a/src/Cobalt/Model/PeopleCustom.php
+++ b/src/Cobalt/Model/PeopleCustom.php
@@ -23,7 +23,7 @@ class PeopleCustom extends DefaultModel
 
     public function store()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new PeopleCustomTable;
@@ -145,7 +145,7 @@ class PeopleCustom extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $filter_order = $app->getUserStateFromRequest('Peoplecustom.filter_order','filter_order','c.name');
         $filter_order_Dir = $app->getUserStateFromRequest('Peoplecustom.filter_order_Dir','filter_order_Dir','asc');
 

--- a/src/Cobalt/Model/Report.php
+++ b/src/Cobalt/Model/Report.php
@@ -30,7 +30,7 @@ class Report extends DefaultModel
      */
     public function store()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new ReportTable;
@@ -89,7 +89,7 @@ class Report extends DefaultModel
      */
     public function getCustomReports($id=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //load database
         $db = JFactory::getDBO();
@@ -147,7 +147,7 @@ class Report extends DefaultModel
         //get db
         $db = JFactory::getDBO();
         $query = $db->getQuery(true);
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //get the custom report so we know what data to filter and select
         $custom_report = $this->getCustomReports($id);
@@ -567,7 +567,7 @@ class Report extends DefaultModel
         function populateState()
         {
             //get states
-            $app = \Cobalt\Container::get('app');
+            $app = \Cobalt\Container::fetch('app');
 
             //determine view so we set correct states
             $view = $app->input->get('view');

--- a/src/Cobalt/Model/Source.php
+++ b/src/Cobalt/Model/Source.php
@@ -84,7 +84,7 @@ class Source extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $filter_order = $app->getUserStateFromRequest('Source.filter_order','filter_order','s.name');
         $filter_order_Dir = $app->getUserStateFromRequest('Source.filter_order_Dir','filter_order_Dir','asc');
 

--- a/src/Cobalt/Model/Sources.php
+++ b/src/Cobalt/Model/Sources.php
@@ -23,7 +23,7 @@ class Sources extends DefaultModel
 
     public function store()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new SourcesTable;
@@ -124,7 +124,7 @@ class Sources extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $filter_order = $app->getUserStateFromRequest('Sources.filter_order','filter_order','s.name');
         $filter_order_Dir = $app->getUserStateFromRequest('Sources.filter_order_Dir','filter_order_Dir','asc');
 

--- a/src/Cobalt/Model/Stages.php
+++ b/src/Cobalt/Model/Stages.php
@@ -23,7 +23,7 @@ class Stages extends DefaultModel
 
     public function store()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new StagesTable;
@@ -126,7 +126,7 @@ class Stages extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $filter_order = $app->getUserStateFromRequest('Stages.filter_order','filter_order','s.name');
         $filter_order_Dir = $app->getUserStateFromRequest('Stages.filter_order_Dir','filter_order_Dir','asc');
 

--- a/src/Cobalt/Model/Statuses.php
+++ b/src/Cobalt/Model/Statuses.php
@@ -24,7 +24,7 @@ class Statuses extends DefaultModel
 
     public function store()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new StatusesTable;
@@ -125,7 +125,7 @@ class Statuses extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $filter_order = $app->getUserStateFromRequest('Statuses.filter_order','filter_order','s.name');
         $filter_order_Dir = $app->getUserStateFromRequest('Statuses.filter_order_Dir','filter_order_Dir','asc');
 

--- a/src/Cobalt/Model/Tags.php
+++ b/src/Cobalt/Model/Tags.php
@@ -88,7 +88,7 @@ class Tags extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $filter_order = $app->getUserStateFromRequest('Tags.filter_order','filter_order','t.name');
         $filter_order_Dir = $app->getUserStateFromRequest('Tags.filter_order_Dir','filter_order_Dir','asc');
 

--- a/src/Cobalt/Model/Template.php
+++ b/src/Cobalt/Model/Template.php
@@ -23,7 +23,7 @@ class Template extends DefaultModel
      */
     public function createTemplate()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         $template_id = $app->input->get('template_id');
         $association_id = $app->input->get('association_id');

--- a/src/Cobalt/Model/Templates.php
+++ b/src/Cobalt/Model/Templates.php
@@ -23,7 +23,7 @@ class Templates extends DefaultModel
 
     public function store()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new TemplatesTable;
@@ -178,7 +178,7 @@ class Templates extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $filter_order = $app->getUserStateFromRequest('Templates.filter_order','filter_order','t.name');
         $filter_order_Dir = $app->getUserStateFromRequest('Templates.filter_order_Dir','filter_order_Dir','asc');
 

--- a/src/Cobalt/Model/User.php
+++ b/src/Cobalt/Model/User.php
@@ -40,7 +40,7 @@ class User extends DefaultModel
     public function __construct($userId = null)
     {
         parent::__construct();
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $this->_view = $app->input->get('view');
         $this->_layout = str_replace('_filter','',$app->input->get('layout'));
 
@@ -296,7 +296,7 @@ class User extends DefaultModel
                 }
             }
         }
-        
+
         // OK, the credentials are authenticated and user is authorised.  Lets fire the onLogin event.
         $this->app->triggerEvent('onUserLogin', array($result, $options));
 
@@ -322,7 +322,7 @@ class User extends DefaultModel
 
             // Check to see the the session already exists.
             $this->app->checkSession();
-            
+
             $this->updateUserSession();
 
             // Hit the user last visit field

--- a/src/Cobalt/Model/Users.php
+++ b/src/Cobalt/Model/Users.php
@@ -23,7 +23,7 @@ class Users extends DefaultModel
 {
     public function store()
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
 
         //Load Tables
         $row = new UsersTable;
@@ -185,7 +185,7 @@ class Users extends DefaultModel
 
     public function getUser($id=null)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $id = $id ? $id : $app->input->get("id");
 
         if ($id > 0) {
@@ -210,7 +210,7 @@ class Users extends DefaultModel
     public function populateState()
     {
         //get states
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $filter_order = $app->getUserStateFromRequest('Users.filter_order','filter_order','u.last_name');
         $filter_order_Dir = $app->getUserStateFromRequest('Users.filter_order_Dir','filter_order_Dir','asc');
 
@@ -321,7 +321,7 @@ class Users extends DefaultModel
 
     public function delete($ids)
     {
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         //get db
         $db = JFactory::getDBO();
         $query = $db->getQuery(true);

--- a/src/Cobalt/Provider/ConfigServiceProvider.php
+++ b/src/Cobalt/Provider/ConfigServiceProvider.php
@@ -10,53 +10,69 @@ namespace Cobalt\Provider;
 
 use JConfig;
 use JFactory;
-use Cobalt\Container;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
 use Joomla\Registry\Registry;
 
+/**
+ * Configuration service provider
+ *
+ * @since  1.0
+ */
 class ConfigServiceProvider implements ServiceProviderInterface
 {
-    public function register(Container $container)
-    {
-        $config = new Registry(new JConfig);
+	/**
+	 * Registers the service provider with a DI container.
+	 *
+	 * @param   Container  $container  The DI container.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function register(Container $container)
+	{
+		$config = new Registry(new JConfig);
 
-        // Set the error_reporting
-        switch ($config->get('error_reporting')) {
-            case 'default':
-            case '-1':
-                break;
+		// Set the error_reporting
+		switch ($config->get('error_reporting'))
+		{
+			case 'default':
+			case '-1':
+				break;
 
-            case 'none':
-            case '0':
-                error_reporting(0);
-                break;
+			case 'none':
+			case '0':
+				error_reporting(0);
+				break;
 
-            case 'simple':
-                error_reporting(E_ERROR | E_WARNING | E_PARSE);
-                ini_set('display_errors', 1);
-                break;
+			case 'simple':
+				error_reporting(E_ERROR | E_WARNING | E_PARSE);
+				ini_set('display_errors', 1);
+				break;
 
-            case 'maximum':
-                error_reporting(E_ALL);
-                ini_set('display_errors', 1);
-                break;
+			case 'maximum':
+				error_reporting(E_ALL);
+				ini_set('display_errors', 1);
+				break;
 
-            case 'development':
-                error_reporting(-1);
-                ini_set('display_errors', 1);
-                break;
+			case 'development':
+				error_reporting(-1);
+				ini_set('display_errors', 1);
+				break;
 
-            default:
-                error_reporting($config->get('error_reporting'));
-                ini_set('display_errors', 1);
-                break;
-        }
+			default:
+				error_reporting($config->get('error_reporting'));
+				ini_set('display_errors', 1);
+				break;
+		}
 
-        JFactory::$config = $config;
+		JFactory::$config = $config;
 
-        define('JDEBUG', $config->get('debug', false));
+		define('JDEBUG', $config->get('debug', false));
 
-        $container->bind('config', function () use ($config) {
-                return $config;
-            });
-    }
+		$container->protect('config', function () use ($config) {
+			return $config;
+		}, true);
+	}
 }

--- a/src/Cobalt/Provider/DatabaseServiceProvider.php
+++ b/src/Cobalt/Provider/DatabaseServiceProvider.php
@@ -9,38 +9,52 @@
 namespace Cobalt\Provider;
 
 use JFactory;
-use Cobalt\Container;
 use Joomla\Database\DatabaseDriver;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
 
+/**
+ * Database service provider
+ *
+ * @since  1.0
+ */
 class DatabaseServiceProvider implements ServiceProviderInterface
 {
+	/**
+	 * Registers the service provider with a DI container.
+	 *
+	 * @param   Container  $container  The DI container.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
     public function register(Container $container)
     {
-        $container->bind('Joomla\\Database\\DatabaseDriver', function() {
-                static $db;
+	    $container->set('Joomla\\Database\\DatabaseDriver',
+            function () use ($container)
+            {
+                $config = $container->get('config');
 
-                if (is_null($db)) {
-                    $config = Container::get('config');
+                $options = array(
+                    'driver' => $config->get('dbtype'),
+                    'host' => $config->get('host'),
+                    'user' => $config->get('user'),
+                    'password' => $config->get('password'),
+                    'database' => $config->get('db'),
+                    'prefix' => $config->get('dbprefix')
+                );
 
-                    $options = array(
-                        'driver' => $config->get('dbtype'),
-                        'host' => $config->get('host'),
-                        'user' => $config->get('user'),
-                        'password' => $config->get('password'),
-                        'database' => $config->get('db'),
-                        'prefix' => $config->get('dbprefix')
-                    );
-
-                    $db = DatabaseDriver::getInstance($options);
-                    $db->setDebug($config->get('debug', false));
-                }
+                $db = DatabaseDriver::getInstance($options);
+                $db->setDebug($config->get('debug', false));
 
                 return $db;
-            });
+            }, true, true
+        );
 
         // Alias the database
         $container->alias('db', 'Joomla\\Database\\DatabaseDriver');
 
-        JFactory::$database = $container->resolve('db');
+        JFactory::$database = $container->get('db');
     }
 }

--- a/src/Cobalt/Provider/SessionServiceProvider.php
+++ b/src/Cobalt/Provider/SessionServiceProvider.php
@@ -9,27 +9,42 @@
 namespace Cobalt\Provider;
 
 use JFactory;
-use Cobalt\Container;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 
+/**
+ * Configuration service provider
+ *
+ * @since  1.0
+ */
 class SessionServiceProvider implements ServiceProviderInterface
 {
-    public function register(Container $container)
-    {
-        $config = $container->resolve('config');
+	/**
+	 * Registers the service provider with a DI container.
+	 *
+	 * @param   Container  $container  The DI container.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function register(Container $container)
+	{
+		$config = $container::fetch('config');
 
-        if ($config->get('session', true) !== false) {
+		if ($config->get('session', true) !== false)
+		{
+			$session = new Session;
 
-            $session = new Session;
+			$session->start();
 
-            $session->start();
+			// @TODO Remove JFactory
+			JFactory::$session = $session;
 
-            // @TODO Remove JFactory
-            JFactory::$session = $session;
-
-            $container->bind('session', function () use ($session) {
-                    return $session;
-                });
-        }
-    }
+			$container->set('session', function () use ($session) {
+				return $session;
+			}, true, true);
+		}
+	}
 }

--- a/src/Cobalt/Router.php
+++ b/src/Cobalt/Router.php
@@ -87,7 +87,7 @@ class Router extends JoomlaRouter
 
     public static function to($url)
     {
-        return RouteHelper::_(\Cobalt\Container::get('app')->getRouter()->getRouteFor($url));
+        return RouteHelper::_(\Cobalt\Container::fetch('app')->getRouter()->getRouteFor($url));
     }
 
     public function getRouteFor($url)

--- a/src/Cobalt/Table/AbstractTable.php
+++ b/src/Cobalt/Table/AbstractTable.php
@@ -77,7 +77,7 @@ class AbstractTable implements \IteratorAggregate
             $this->tableName = $table;
         }
 
-        $this->db          = $db ?: Container::get('db');
+        $this->db          = $db ?: Container::fetch('db');
         $this->tableFields = new \stdClass;
 
         // Set the key to be an array.

--- a/src/Cobalt/View/AdminImport/Html.php
+++ b/src/Cobalt/View/AdminImport/Html.php
@@ -29,7 +29,7 @@ class Html extends AbstractHtmlView
         UsersHelper::authenticateAdmin();
 
         //app
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         if ($app->input->get('layout')=='sample') {
             $this->_displaySample($tpl);
 
@@ -107,7 +107,7 @@ class Html extends AbstractHtmlView
         /** Menu Links **/
         $menu = MenuHelper::getMenuModules();
         $this->menu = $menu;
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $doc = $app->getDocument();
         $doc->addScript(JURI::base()."/src/Cobalt/media/js/cobalt-admin.js");
 

--- a/src/Cobalt/View/Cobalt/Html.php
+++ b/src/Cobalt/View/Cobalt/Html.php
@@ -27,7 +27,7 @@ class Html extends AbstractHtmlView
     {
         //authenticate the current user to make sure they are an admin
         UsersHelper::authenticateAdmin();
-        $app = \Cobalt\Container::get('app');
+        $app = \Cobalt\Container::fetch('app');
         $document = $app->getDocument();
         $document->addScript(JURI::base().'src/Cobalt/media/js/cobalt-admin.js');
 

--- a/src/Cobalt/cobalt.php
+++ b/src/Cobalt/cobalt.php
@@ -10,6 +10,8 @@
 // No direct access
 defined( '_CEXEC' ) or die( 'Restricted access' );
 
+/** @type \Cobalt\Application $this */
+
 use Cobalt\Helper\UsersHelper;
 use Cobalt\Helper\ActivityHelper;
 use Cobalt\Helper\DateHelper;
@@ -25,20 +27,17 @@ $tz = DateHelper::getSiteTimezone();
 //Load plugins
 JPluginHelper::importPlugin('cobalt');
 
-/** @var \Cobalt\Application $app */
-$app = Cobalt\Container::get('app');
-
 //get user object
-$user = $app->getUser();
+$user = $this->getUser();
 
 // Fetch the controller
-$controllerObj = $app->getRouter()->getController($app->get('uri.route'));
+$controllerObj = $this->getRouter()->getController($this->get('uri.route'));
 
 // Require specific controller if requested
-$controller = $app->input->get('controller', 'default');
+$controller = $this->input->get('controller', 'default');
 
 //load user toolbar
-$format = $app->input->get('format');
+$format = $this->input->get('format');
 
 $overrides = array('ajax', 'mail', 'login');
 
@@ -49,12 +48,12 @@ if ($loggedIn && $format !== 'raw' && !in_array($controller, $overrides)) {
     ActivityHelper::saveUserLoginHistory();
 
     // Set a default view if none exists
-    if (! $app->input->get('view')) {
-        $app->input->set('view', 'dashboard' );
+    if (! $this->input->get('view')) {
+        $this->input->set('view', 'dashboard' );
     }
 
     //Grab document instance
-    $document = $app->getDocument();
+    $document = $this->getDocument();
 
     //load scripts
     $document->addScript( JURI::base().'libraries/crm/media/js/jquery.js' );
@@ -66,14 +65,14 @@ if ($loggedIn && $format !== 'raw' && !in_array($controller, $overrides)) {
     $document->addScript( JURI::base().'libraries/crm/media/js/bootstrap-fileupload.js' );
 
     //start component div wrapper
-    if ( $app->input->get('view') != "print") {
+    if ( $this->input->get('view') != "print") {
         TemplateHelper::loadToolbar();
     }
     TemplateHelper::startCompWrap();
 
     //mobile detection
     if (TemplateHelper::isMobile()) {
-         $app->input->set('tmpl','component');
+         $this->input->set('tmpl','component');
          $document->addScript('http://maps.google.com/maps/api/js?sensor=false');
          $document->addScript( JURI::base().'libraries/crm/media/js/jquery.mobile.1.0.1.min.js' );
          $document->addScript( JURI::base().'libraries/crm/media/js/jquery.mobile.datepicker.js' );
@@ -100,12 +99,12 @@ if ($loggedIn && $format !== 'raw' && !in_array($controller, $overrides)) {
 }
 
 if (!$loggedIn && !($controllerObj instanceof Cobalt\Controller\Login)) {
-    $app->redirect(RouteHelper::_('index.php?view=login'));
+    $this->redirect(RouteHelper::_('index.php?view=login'));
 }
 
 //fullscreen detection
 if (UsersHelper::isFullscreen()) {
-    $app->input->set('tmpl', 'component' );
+    $this->input->set('tmpl', 'component' );
 }
 
 // Perform the Request task

--- a/src/boot.php
+++ b/src/boot.php
@@ -28,8 +28,8 @@ require_once JPATH_VENDOR.'/autoload.php';
 //
 // Installation check, and check on removal of the install directory.
 //
-if (!file_exists(JPATH_CONFIGURATION.'/configuration.php') 
-    || (filesize(JPATH_CONFIGURATION.'/configuration.php') < 10) 
+if (!file_exists(JPATH_CONFIGURATION.'/configuration.php')
+    || (filesize(JPATH_CONFIGURATION.'/configuration.php') < 10)
     || file_exists(JPATH_INSTALLATION.'/index.php')) {
 
     //checking server REQUEST_SCHEME
@@ -38,7 +38,7 @@ if (!file_exists(JPATH_CONFIGURATION.'/configuration.php')
     }
 
     $installUri = $_SERVER['REQUEST_SCHEME'].'://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI'].'install/index.php';
-    
+
     if (file_exists(JPATH_INSTALLATION.'/index.php')) {
         header('Location: '.$installUri);
         exit();
@@ -59,26 +59,19 @@ JLoader::registerPrefix('Modular', JPATH_SITE.'/libraries/modular/');
 $container = Cobalt\Container::getInstance();
 
 $container
-    ->registerServiceProvider(new Cobalt\Provider\ConfigServiceProvider)
-    ->registerServiceProvider(new Cobalt\Provider\SessionServiceProvider)
-    ->registerServiceProvider(new Cobalt\Provider\DatabaseServiceProvider);
-//    ->registerServiceProvider(new Cobalt\Provider\WhoopsServiceProvider);
+    ->registerServiceProvider(new \Cobalt\Provider\ConfigServiceProvider)
+    ->registerServiceProvider(new \Cobalt\Provider\DatabaseServiceProvider)
+	->registerServiceProvider(new \Cobalt\Provider\SessionServiceProvider);
 
-$container->bind('app', function($c) {
-        static $app;
+$container->set('app', function($c) {
+	/** @var $c \Joomla\DI\Container */
+	$app = new \Cobalt\Application($c);
 
-        if (is_null($app)) {
-            /** @var $c \Cobalt\Container */
-            $c->registerProviders();
+    // @TODO: Remove JFactory
+    JFactory::$application = $app;
 
-            $app = new Cobalt\Application;
-
-            // @TODO: Remove JFactory
-            JFactory::$application = $app;
-        }
-
-        return $app;
-    });
+    return $app;
+}, true, true);
 
 // Alias the helper classes, so we don't have to add the use statement to every layout.
 $helpers = glob(JPATH_ROOT . '/src/Cobalt/Helper/*.php');


### PR DESCRIPTION
Why?  The League\DI package is deprecated and the features it was lacking, leading to `Cobalt\Container` being created were added to Joomla's DI container.

TODO - Stop using the container as a Service Locator and refactor to proper DI.
